### PR TITLE
Add derived candle metrics to `ohlcv_candles`

### DIFF
--- a/apps/candle-collector/src/db/migrations/0000_create_ohlcv_candles.sql
+++ b/apps/candle-collector/src/db/migrations/0000_create_ohlcv_candles.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "ohlcv_candles" (
+	"instrument" varchar(100) NOT NULL,
+	"open_time" bigint NOT NULL,
+	"timeframe" varchar(10) NOT NULL,
+	"open" double precision NOT NULL,
+	"high" double precision NOT NULL,
+	"low" double precision NOT NULL,
+	"close" double precision NOT NULL,
+	"volume" double precision NOT NULL,
+	"quote_volume" double precision NOT NULL,
+	"num_trades" bigint NOT NULL,
+	CONSTRAINT "ohlcv_candles_instrument_open_time_timeframe_pk" PRIMARY KEY("instrument","open_time","timeframe")
+);

--- a/apps/candle-collector/src/db/migrations/0001_add_derived_candle_metrics.sql
+++ b/apps/candle-collector/src/db/migrations/0001_add_derived_candle_metrics.sql
@@ -6,8 +6,9 @@ ALTER TABLE "ohlcv_candles" ADD COLUMN "body_ratio" double precision;
 -- Backfill any existing rows before enforcing NOT NULL
 UPDATE "ohlcv_candles"
 SET
-  pct_change   = ((close - open) / open) * 100,
-  candle_range = ((high - low) / open) * 100,
+  pct_change   = CASE WHEN open = 0 THEN 0 ELSE ((close - open) / open) * 100 END,
+  candle_range = CASE WHEN open = 0 THEN 0 ELSE ((high - low) / open) * 100 END,
+  -- When high = low (zero-range / doji candle), treat body as 100% of range by convention
   body_ratio   = CASE WHEN high = low THEN 1.0 ELSE ABS(close - open) / (high - low) END;
 
 -- Enforce NOT NULL now that all rows have values

--- a/apps/candle-collector/src/db/migrations/0001_add_derived_candle_metrics.sql
+++ b/apps/candle-collector/src/db/migrations/0001_add_derived_candle_metrics.sql
@@ -1,0 +1,16 @@
+-- Add derived candle metric columns as nullable first to allow backfill of any existing rows
+ALTER TABLE "ohlcv_candles" ADD COLUMN "pct_change" double precision;
+ALTER TABLE "ohlcv_candles" ADD COLUMN "candle_range" double precision;
+ALTER TABLE "ohlcv_candles" ADD COLUMN "body_ratio" double precision;
+
+-- Backfill any existing rows before enforcing NOT NULL
+UPDATE "ohlcv_candles"
+SET
+  pct_change   = ((close - open) / open) * 100,
+  candle_range = ((high - low) / open) * 100,
+  body_ratio   = CASE WHEN high = low THEN 1.0 ELSE ABS(close - open) / (high - low) END;
+
+-- Enforce NOT NULL now that all rows have values
+ALTER TABLE "ohlcv_candles" ALTER COLUMN "pct_change" SET NOT NULL;
+ALTER TABLE "ohlcv_candles" ALTER COLUMN "candle_range" SET NOT NULL;
+ALTER TABLE "ohlcv_candles" ALTER COLUMN "body_ratio" SET NOT NULL;

--- a/apps/candle-collector/src/db/migrations/meta/_journal.json
+++ b/apps/candle-collector/src/db/migrations/meta/_journal.json
@@ -1,0 +1,20 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1742457600000,
+      "tag": "0000_create_ohlcv_candles",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1742461200000,
+      "tag": "0001_add_derived_candle_metrics",
+      "breakpoints": true
+    }
+  ]
+}

--- a/apps/candle-collector/src/db/schema.ts
+++ b/apps/candle-collector/src/db/schema.ts
@@ -13,6 +13,11 @@ export const ohlcvCandles = pgTable(
     volume: doublePrecision('volume').notNull(),
     quote_volume: doublePrecision('quote_volume').notNull(),
     num_trades: bigint('num_trades', { mode: 'number' }).notNull(),
+
+    // derived — computed at ingestion time
+    pct_change: doublePrecision('pct_change').notNull(),
+    candle_range: doublePrecision('candle_range').notNull(),
+    body_ratio: doublePrecision('body_ratio').notNull(),
   },
   (table) => [primaryKey({ columns: [table.instrument, table.open_time, table.timeframe] })],
 );

--- a/apps/candle-collector/src/routes/ohlc/handler.ts
+++ b/apps/candle-collector/src/routes/ohlc/handler.ts
@@ -39,17 +39,21 @@ function getClosestAggregateTs(intervalSeconds: number): number {
 }
 
 function normalize(record: CoindeskRecord, instrument: string, timeframe: string): NewOhlcvCandle {
+  const { OPEN: open, HIGH: high, LOW: low, CLOSE: close } = record;
   return {
     open_time: record.TIMESTAMP,
-    open: record.OPEN,
-    high: record.HIGH,
-    low: record.LOW,
-    close: record.CLOSE,
+    open,
+    high,
+    low,
+    close,
     volume: record.VOLUME,
     quote_volume: record.QUOTE_VOLUME,
     num_trades: record.TOTAL_TRADES,
     instrument,
     timeframe,
+    pct_change: ((close - open) / open) * 100,
+    candle_range: ((high - low) / open) * 100,
+    body_ratio: high === low ? 1.0 : Math.abs(close - open) / (high - low),
   };
 }
 

--- a/apps/candle-collector/src/routes/ohlc/handler.ts
+++ b/apps/candle-collector/src/routes/ohlc/handler.ts
@@ -51,8 +51,8 @@ function normalize(record: CoindeskRecord, instrument: string, timeframe: string
     num_trades: record.TOTAL_TRADES,
     instrument,
     timeframe,
-    pct_change: ((close - open) / open) * 100,
-    candle_range: ((high - low) / open) * 100,
+    pct_change: open !== 0 ? ((close - open) / open) * 100 : 0,
+    candle_range: open !== 0 ? ((high - low) / open) * 100 : 0,
     body_ratio: high === low ? 1.0 : Math.abs(close - open) / (high - low),
   };
 }


### PR DESCRIPTION
Add `pct_change`, `candle_range`, and `body_ratio` columns to the `ohlcv_candles` table. Values are computed at ingestion time in the `normalize()` function. Migration 0001 uses a nullable-add → backfill → NOT NULL pattern for safe production deploys.

Closes #8

Generated with [Claude Code](https://claude.ai/code)