### PR TITLE
Seed in-memory candle state on startup via Binance REST API

### DIFF
--- a/apps/binance-stream/pyproject.toml
+++ b/apps/binance-stream/pyproject.toml
@@ -11,6 +11,7 @@ python = "^3.12"
 fastapi = "^0.115.0"
 uvicorn = { extras = ["standard"], version = "^0.34.0" }
 websockets = "^14.1"
+httpx = "^0.28.0"
 asyncpg = "^0.30.0"
 python-dotenv = "^1.0.0"
 

--- a/apps/binance-stream/src/main.py
+++ b/apps/binance-stream/src/main.py
@@ -13,7 +13,7 @@ from fastapi.openapi.utils import get_openapi
 from pydantic import BaseModel
 
 from .connection_manager import ConnectionManager
-from .stream import run_binance_stream
+from .stream import fetch_initial_candles, run_binance_stream
 
 
 class HealthResponse(BaseModel):
@@ -40,6 +40,10 @@ TRACKED_PAIRS = ["btcusdt"]
 async def lifespan(_: FastAPI):
     for pair in TRACKED_PAIRS:
         _managers[pair] = ConnectionManager()
+        initial_candles = await fetch_initial_candles(pair)
+        for candle in initial_candles:
+            _managers[pair].update_closed_candle(candle)
+        logger.info("Seeded %d initial candles for %s", len(initial_candles), pair)
         _stream_tasks[pair] = asyncio.create_task(
             run_binance_stream(pair, _managers[pair]),
             name=f"binance-kline-{pair}",

--- a/apps/binance-stream/src/stream.py
+++ b/apps/binance-stream/src/stream.py
@@ -10,6 +10,7 @@ import asyncio
 import json
 import logging
 
+import httpx
 from websockets.asyncio.client import connect
 from websockets.exceptions import ConnectionClosed
 
@@ -19,10 +20,49 @@ from .models import kline_message_to_dict, parse_kline_message
 logger = logging.getLogger(__name__)
 
 BINANCE_FUTURES_WS_BASE = "wss://fstream.binance.com/ws"
+BINANCE_FUTURES_REST_BASE = "https://fapi.binance.com"
 
 
 def make_stream_url(pair: str) -> str:
     return f"{BINANCE_FUTURES_WS_BASE}/{pair.lower()}_perpetual@continuousKline_5m"
+
+
+def _rest_candle_to_dict(candle: list, pair: str) -> dict:
+    """Convert a Binance REST continuousKlines array entry to the standard kline dict format."""
+    return {
+        "type": "kline",
+        "event_time": candle[6],  # use close_time as event_time for historical candles
+        "pair": pair.upper(),
+        "contract_type": "PERPETUAL",
+        "kline": {
+            "open_time": candle[0],
+            "close_time": candle[6],
+            "interval": "5m",
+            "open": candle[1],
+            "high": candle[2],
+            "low": candle[3],
+            "close": candle[4],
+            "volume": candle[5],
+            "num_trades": candle[8],
+            "is_closed": True,
+        },
+    }
+
+
+async def fetch_initial_candles(pair: str) -> list[dict]:
+    """Fetch the last 3 closed candles from the Binance REST API to seed in-memory state."""
+    url = f"{BINANCE_FUTURES_REST_BASE}/fapi/v1/continuousKlines"
+    params = {
+        "pair": pair.upper(),
+        "contractType": "PERPETUAL",
+        "interval": "5m",
+        "limit": 4,  # fetch 4, discard the currently forming one
+    }
+    async with httpx.AsyncClient() as client:
+        response = await client.get(url, params=params)
+        response.raise_for_status()
+        candles = response.json()
+        return [_rest_candle_to_dict(c, pair) for c in candles[:-1]]
 
 
 async def _handle_message(raw_text: str, cm: ConnectionManager) -> None:


### PR DESCRIPTION
Fetch the last 3 closed candles from the Binance USDS Futures REST API during lifespan startup and pre-populate each ConnectionManager's closed_candles list before the WebSocket stream task starts.

Closes #11

Generated with [Claude Code](https://claude.ai/code)