### PR TITLE
Send snapshot on connect and differentiate message types

### DIFF
--- a/apps/binance-stream/src/connection_manager.py
+++ b/apps/binance-stream/src/connection_manager.py
@@ -18,6 +18,11 @@ class ConnectionManager:
     async def connect(self, websocket: WebSocket) -> None:
         await websocket.accept()
         self._clients.add(websocket)
+        await websocket.send_json({
+            "type": "snapshot",
+            "closed_candles": self.closed_candles,
+            "current_candle": self.current_candle,
+        })
 
     async def disconnect(self, websocket: WebSocket) -> None:
         self._clients.discard(websocket)

--- a/apps/binance-stream/src/stream.py
+++ b/apps/binance-stream/src/stream.py
@@ -81,7 +81,13 @@ async def _handle_message(raw_text: str, cm: ConnectionManager) -> None:
         logger.warning("Failed to parse kline message: %s", exc)
         return
 
-    await cm.broadcast(kline_message_to_dict(msg))
+    candle_dict = kline_message_to_dict(msg)
+    if msg.kline.is_closed:
+        cm.update_closed_candle(candle_dict)
+        await cm.broadcast({**candle_dict, "type": "candle_closed"})
+    else:
+        cm.update_current_candle(candle_dict)
+        await cm.broadcast({**candle_dict, "type": "tick"})
 
 
 async def run_binance_stream(pair: str, cm: ConnectionManager) -> None:


### PR DESCRIPTION
Sends a `snapshot` message immediately on WebSocket connect containing the last 3 closed candles and the current forming candle. Subsequent messages are now typed as `tick` or `candle_closed` instead of the generic `kline` type.

Closes #13

Generated with [Claude Code](https://claude.ai/code)