### PR TITLE
Address code review findings and improve stream stability

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -42,4 +42,5 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
+          allowed_bots: 'claude[bot]'
 

--- a/apps/binance-stream/.env.example
+++ b/apps/binance-stream/.env.example
@@ -9,3 +9,4 @@ DATABASE_URL=postgresql://user:password@localhost:5432/crypto_terminal
 HOST=0.0.0.0
 PORT=3001
 LOG_LEVEL=info
+CORS_ORIGINS=["http://localhost:3000"]

--- a/apps/binance-stream/.env.example
+++ b/apps/binance-stream/.env.example
@@ -2,9 +2,6 @@
 BINANCE_API_KEY=your_api_key_here
 BINANCE_API_SECRET=your_api_secret_here
 
-# PostgreSQL Database
-DATABASE_URL=postgresql://user:password@localhost:5432/crypto_terminal
-
 # Server Configuration
 HOST=0.0.0.0
 PORT=3001

--- a/apps/binance-stream/pyproject.toml
+++ b/apps/binance-stream/pyproject.toml
@@ -12,8 +12,7 @@ fastapi = "^0.115.0"
 uvicorn = { extras = ["standard"], version = "^0.34.0" }
 websockets = "^14.1"
 httpx = "^0.28.0"
-asyncpg = "^0.30.0"
-python-dotenv = "^1.0.0"
+pydantic-settings = "^2.0.0"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.8.0"

--- a/apps/binance-stream/src/config.py
+++ b/apps/binance-stream/src/config.py
@@ -1,0 +1,24 @@
+"""
+Application settings loaded from environment variables / .env file via pydantic-settings.
+"""
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+
+    cors_origins: list[str] = ["http://localhost:3000"]
+    log_level: str = "INFO"
+    host: str = "0.0.0.0"
+    port: int = 3001
+    binance_api_key: str = ""
+    binance_api_secret: str = ""
+    database_url: str = ""
+
+
+settings = Settings()

--- a/apps/binance-stream/src/config.py
+++ b/apps/binance-stream/src/config.py
@@ -18,7 +18,6 @@ class Settings(BaseSettings):
     port: int = 3001
     binance_api_key: str = ""
     binance_api_secret: str = ""
-    database_url: str = ""
 
 
 settings = Settings()

--- a/apps/binance-stream/src/connection_manager.py
+++ b/apps/binance-stream/src/connection_manager.py
@@ -33,7 +33,7 @@ class ConnectionManager:
             try:
                 await client.send_json(payload)
             except Exception:
-                logger.warning("Failed to send to client, removing")
+                logger.warning("Failed to send to client, removing", exc_info=True)
                 failed.append(client)
         for client in failed:
             self._clients.discard(client)
@@ -45,8 +45,11 @@ class ConnectionManager:
     def update_current_candle(self, candle: dict) -> None:
         self.current_candle = candle
 
+    def mark_current_candle_stale(self) -> None:
+        """Mark the current in-progress candle as stale after a stream reconnect."""
+        if self.current_candle is not None:
+            self.current_candle = {**self.current_candle, "stale": True}
+
     @property
     def client_count(self) -> int:
         return len(self._clients)
-
-

--- a/apps/binance-stream/src/main.py
+++ b/apps/binance-stream/src/main.py
@@ -12,6 +12,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
 from pydantic import BaseModel
 
+from .config import settings
 from .connection_manager import ConnectionManager
 from .stream import fetch_initial_candles, run_binance_stream
 
@@ -23,7 +24,7 @@ class HealthResponse(BaseModel):
     active_streams: list[str]
 
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=settings.log_level.upper())
 _ws_logger = logging.getLogger("websockets")
 _ws_logger.setLevel(logging.WARNING)
 _ws_logger.propagate = False
@@ -39,15 +40,18 @@ TRACKED_PAIRS = ["btcusdt"]
 @asynccontextmanager
 async def lifespan(_: FastAPI):
     for pair in TRACKED_PAIRS:
-        _managers[pair] = ConnectionManager()
-        initial_candles = await fetch_initial_candles(pair)
-        for candle in initial_candles:
-            _managers[pair].update_closed_candle(candle)
-        logger.info("Seeded %d initial candles for %s", len(initial_candles), pair)
-        _stream_tasks[pair] = asyncio.create_task(
-            run_binance_stream(pair, _managers[pair]),
-            name=f"binance-kline-{pair}",
-        )
+        try:
+            _managers[pair] = ConnectionManager()
+            initial_candles = await fetch_initial_candles(pair)
+            for candle in initial_candles:
+                _managers[pair].update_closed_candle(candle)
+            logger.info("Seeded %d initial candles for %s", len(initial_candles), pair)
+            _stream_tasks[pair] = asyncio.create_task(
+                run_binance_stream(pair, _managers[pair]),
+                name=f"binance-kline-{pair}",
+            )
+        except Exception:
+            logger.exception("Failed to initialize stream for %s, skipping", pair)
     logger.info("All stream tasks started")
 
     yield
@@ -65,6 +69,7 @@ app = FastAPI(
     version="0.1.0",
     lifespan=lifespan,
 )
+
 
 def _custom_openapi() -> dict:
     if app.openapi_schema:
@@ -93,7 +98,7 @@ def _custom_openapi() -> dict:
                     "in": "path",
                     "required": True,
                     "schema": {"type": "string", "example": "btcusdt"},
-                    "description": "Lowercase pair symbol, e.g. `btcusdt`, `ethusdt`.",
+                    "description": "Lowercase pair symbol tracked by this service, e.g. `btcusdt`.",
                 }
             ],
             "responses": {
@@ -109,7 +114,7 @@ app.openapi = _custom_openapi  # type: ignore[method-assign]
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000"],
+    allow_origins=settings.cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
@@ -130,7 +135,7 @@ async def kline_endpoint(websocket: WebSocket, pair: str):
     logger.info("Client connected to %s/kline (%d total)", pair, cm.client_count)
     try:
         while True:
-            await websocket.receive_text()
+            await websocket.receive()
     except WebSocketDisconnect:
         logger.info("Client disconnected from %s/kline", pair)
     finally:
@@ -144,8 +149,8 @@ async def health():
     return {
         "status": "ok",
         "service": "binance-stream",
-        "version": "0.1.0",
-        "active_streams": list(_stream_tasks.keys()),
+        "version": app.version,
+        "active_streams": [pair for pair, task in _stream_tasks.items() if not task.done()],
     }
 
 

--- a/apps/binance-stream/src/stream.py
+++ b/apps/binance-stream/src/stream.py
@@ -22,6 +22,9 @@ logger = logging.getLogger(__name__)
 BINANCE_FUTURES_WS_BASE = "wss://fstream.binance.com/ws"
 BINANCE_FUTURES_REST_BASE = "https://fapi.binance.com"
 
+# Minimum number of fields required in a REST kline entry.
+_REST_CANDLE_MIN_FIELDS = 9
+
 
 def make_stream_url(pair: str) -> str:
     return f"{BINANCE_FUTURES_WS_BASE}/{pair.lower()}_perpetual@continuousKline_5m"
@@ -29,6 +32,10 @@ def make_stream_url(pair: str) -> str:
 
 def _rest_candle_to_dict(candle: list, pair: str) -> dict:
     """Convert a Binance REST continuousKlines array entry to the standard kline dict format."""
+    if len(candle) < _REST_CANDLE_MIN_FIELDS:
+        raise ValueError(
+            f"Candle entry has {len(candle)} fields, expected at least {_REST_CANDLE_MIN_FIELDS}"
+        )
     return {
         "type": "kline",
         "event_time": candle[6],  # use close_time as event_time for historical candles
@@ -58,7 +65,7 @@ async def fetch_initial_candles(pair: str) -> list[dict]:
         "interval": "5m",
         "limit": 4,  # fetch 4, discard the currently forming one
     }
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=httpx.Timeout(10.0)) as client:
         response = await client.get(url, params=params)
         response.raise_for_status()
         candles = response.json()
@@ -93,7 +100,13 @@ async def _handle_message(raw_text: str, cm: ConnectionManager) -> None:
 async def run_binance_stream(pair: str, cm: ConnectionManager) -> None:
     url = make_stream_url(pair)
     logger.info("Starting Binance futures kline stream: %s", url)
-    async for websocket in connect(url):
+    first = True
+    # delay_min/delay_max configure the exponential backoff between reconnect attempts.
+    async for websocket in connect(url, delay_min=1, delay_max=60):
+        if not first:
+            logger.warning("Binance WebSocket reconnected for %s, marking current candle stale", pair)
+            cm.mark_current_candle_stale()
+        first = False
         try:
             async for message in websocket:
                 await _handle_message(message, cm)
@@ -103,3 +116,6 @@ async def run_binance_stream(pair: str, cm: ConnectionManager) -> None:
         except asyncio.CancelledError:
             logger.info("Binance stream task cancelled for %s", pair)
             raise
+        except Exception:
+            logger.exception("Unexpected error in stream for %s, reconnecting...", pair)
+            continue


### PR DESCRIPTION
Implements all 14 fixes from the code review:

- Add 10s timeout to `fetch_initial_candles`
- Catch unexpected exceptions in `run_binance_stream` to prevent permanent stream death
- Filter done tasks from health `active_streams`
- Use `websocket.receive()` instead of `receive_text()`
- Add bounds check in `_rest_candle_to_dict`
- Drive CORS origins from pydantic settings
- Wrap per-pair lifespan init in try/except
- Log exception info in broadcast failure
- Mark `current_candle` stale on stream reconnect
- Remove unused `asyncpg` dependency
- Load .env via pydantic-settings, replace python-dotenv
- Fix misleading OpenAPI path param description
- Deduplicate version string — use `app.version` in health response
- Configure explicit reconnection backoff (delay_min=1, delay_max=60)

Closes #19

Generated with [Claude Code](https://claude.ai/code)