### PR TITLE
Implement crypto news SSE endpoints with caching and tests

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,8 @@
     "tailwind-merge": "^3",
     "tailwind-variants": "^3",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^3"
   },
   "name": "web",
   "private": true,
@@ -24,7 +25,8 @@
     "dev": "next dev",
     "lint": "biome check",
     "lint:fix": "biome check --write --unsafe",
-    "start": "next start"
+    "start": "next start",
+    "test": "vitest run"
   },
   "version": "0.1.0"
 }

--- a/apps/web/src/app/api/news/coin/route.ts
+++ b/apps/web/src/app/api/news/coin/route.ts
@@ -1,0 +1,140 @@
+import type { Article, CacheEntry } from '@/lib/news/cache';
+import { getCoinCache, setCoinCache } from '@/lib/news/cache';
+
+const POLL_INTERVAL = 60_000;
+const FETCH_TIMEOUT = 5_000;
+
+function parseArticle(raw: unknown): Article | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const r = raw as Record<string, unknown>;
+  const link =
+    typeof r.link === 'string' ? r.link : typeof r.url === 'string' ? r.url : '';
+  if (!link) return null;
+  const title = typeof r.title === 'string' ? r.title : '';
+  const description = typeof r.description === 'string' ? r.description : '';
+  const pubDate =
+    typeof r.pubDate === 'string'
+      ? r.pubDate
+      : typeof r.publishedAt === 'string'
+        ? r.publishedAt
+        : '';
+  const source =
+    typeof r.source === 'string'
+      ? r.source
+      : r.source !== null &&
+          typeof r.source === 'object' &&
+          typeof (r.source as Record<string, unknown>).name === 'string'
+        ? ((r.source as Record<string, unknown>).name as string)
+        : '';
+  const timeAgo = typeof r.timeAgo === 'string' ? r.timeAgo : '';
+  return { description, link, pubDate, source, timeAgo, title };
+}
+
+function mapArticles(data: unknown): Article[] {
+  if (Array.isArray(data)) {
+    return data.map(parseArticle).filter((a): a is Article => a !== null);
+  }
+  if (data && typeof data === 'object') {
+    const d = data as Record<string, unknown>;
+    if (Array.isArray(d.data)) {
+      return d.data.map(parseArticle).filter((a): a is Article => a !== null);
+    }
+    if (Array.isArray(d.articles)) {
+      return d.articles.map(parseArticle).filter((a): a is Article => a !== null);
+    }
+  }
+  return [];
+}
+
+async function fetchWithTimeout(url: string): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT);
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    clearTimeout(timeout);
+    return res;
+  } catch (err) {
+    clearTimeout(timeout);
+    throw err;
+  }
+}
+
+async function fetchCoinNews(coin: string): Promise<Article[] | null> {
+  const url = `https://cryptocurrency.cv/api/search?q=${encodeURIComponent(coin)}&limit=20`;
+  try {
+    const res = await fetchWithTimeout(url);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data: unknown = await res.json();
+    return mapArticles(data);
+  } catch (err) {
+    console.error(
+      `[news/coin] Fetch failed for coin=${coin} at ${new Date().toISOString()}:`,
+      err,
+    );
+    return null;
+  }
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const { searchParams } = new URL(request.url);
+  const coin = searchParams.get('coin');
+
+  if (!coin) {
+    return new Response(JSON.stringify({ error: 'Missing required query param: coin' }), {
+      headers: { 'Content-Type': 'application/json' },
+      status: 400,
+    });
+  }
+
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      const enqueue = (entry: CacheEntry) => {
+        const payload = JSON.stringify({
+          articles: entry.articles,
+          fetchedAt: new Date(entry.fetchedAt).toISOString(),
+        });
+        controller.enqueue(encoder.encode(`data: ${payload}\n\n`));
+      };
+
+      const initial = getCoinCache(coin);
+      const initialEntry: CacheEntry = initial ?? { articles: [], fetchedAt: Date.now() };
+      enqueue(initialEntry);
+
+      let lastLinks = new Set(initialEntry.articles.map(a => a.link));
+
+      const poll = async () => {
+        if (request.signal.aborted) return;
+        const articles = await fetchCoinNews(coin);
+        if (articles === null) return;
+        const fetchedAt = Date.now();
+        const entry: CacheEntry = { articles, fetchedAt };
+        setCoinCache(coin, entry);
+        const newLinks = new Set(articles.map(a => a.link));
+        const changed =
+          articles.some(a => !lastLinks.has(a.link)) ||
+          [...lastLinks].some(l => !newLinks.has(l));
+        if (changed) {
+          lastLinks = newLinks;
+          enqueue(entry);
+        }
+      };
+
+      const interval = setInterval(poll, POLL_INTERVAL);
+
+      request.signal.addEventListener('abort', () => {
+        clearInterval(interval);
+        controller.close();
+      });
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+      'Content-Type': 'text/event-stream',
+    },
+  });
+}

--- a/apps/web/src/app/api/news/global/route.ts
+++ b/apps/web/src/app/api/news/global/route.ts
@@ -1,0 +1,138 @@
+import type { Article, CacheEntry } from '@/lib/news/cache';
+import { getGlobalCache, setGlobalCache } from '@/lib/news/cache';
+
+const PRIMARY_URL = 'https://cryptocurrency.cv/api/news?limit=20';
+const FALLBACK_URL = 'https://nirholas.github.io/free-crypto-news/cache/latest.json';
+const POLL_INTERVAL = 60_000;
+const FETCH_TIMEOUT = 5_000;
+
+function parseArticle(raw: unknown): Article | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const r = raw as Record<string, unknown>;
+  const link =
+    typeof r.link === 'string' ? r.link : typeof r.url === 'string' ? r.url : '';
+  if (!link) return null;
+  const title = typeof r.title === 'string' ? r.title : '';
+  const description = typeof r.description === 'string' ? r.description : '';
+  const pubDate =
+    typeof r.pubDate === 'string'
+      ? r.pubDate
+      : typeof r.publishedAt === 'string'
+        ? r.publishedAt
+        : '';
+  const source =
+    typeof r.source === 'string'
+      ? r.source
+      : r.source !== null &&
+          typeof r.source === 'object' &&
+          typeof (r.source as Record<string, unknown>).name === 'string'
+        ? ((r.source as Record<string, unknown>).name as string)
+        : '';
+  const timeAgo = typeof r.timeAgo === 'string' ? r.timeAgo : '';
+  return { description, link, pubDate, source, timeAgo, title };
+}
+
+function mapArticles(data: unknown): Article[] {
+  if (Array.isArray(data)) {
+    return data.map(parseArticle).filter((a): a is Article => a !== null);
+  }
+  if (data && typeof data === 'object') {
+    const d = data as Record<string, unknown>;
+    if (Array.isArray(d.data)) {
+      return d.data.map(parseArticle).filter((a): a is Article => a !== null);
+    }
+    if (Array.isArray(d.articles)) {
+      return d.articles.map(parseArticle).filter((a): a is Article => a !== null);
+    }
+  }
+  return [];
+}
+
+async function fetchWithTimeout(url: string): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT);
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    clearTimeout(timeout);
+    return res;
+  } catch (err) {
+    clearTimeout(timeout);
+    throw err;
+  }
+}
+
+async function fetchGlobalNews(): Promise<Article[] | null> {
+  try {
+    const res = await fetchWithTimeout(PRIMARY_URL);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data: unknown = await res.json();
+    return mapArticles(data);
+  } catch (err) {
+    console.error(`[news/global] Primary fetch failed at ${new Date().toISOString()}:`, err);
+  }
+
+  try {
+    const res = await fetchWithTimeout(FALLBACK_URL);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data: unknown = await res.json();
+    return mapArticles(data);
+  } catch (err) {
+    console.error(`[news/global] Fallback fetch failed at ${new Date().toISOString()}:`, err);
+  }
+
+  return null;
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      const enqueue = (entry: CacheEntry) => {
+        const payload = JSON.stringify({
+          articles: entry.articles,
+          fetchedAt: new Date(entry.fetchedAt).toISOString(),
+        });
+        controller.enqueue(encoder.encode(`data: ${payload}\n\n`));
+      };
+
+      const initial = getGlobalCache();
+      const initialEntry: CacheEntry = initial ?? { articles: [], fetchedAt: Date.now() };
+      enqueue(initialEntry);
+
+      let lastLinks = new Set(initialEntry.articles.map(a => a.link));
+
+      const poll = async () => {
+        if (request.signal.aborted) return;
+        const articles = await fetchGlobalNews();
+        if (articles === null) return;
+        const fetchedAt = Date.now();
+        const entry: CacheEntry = { articles, fetchedAt };
+        setGlobalCache(entry);
+        const newLinks = new Set(articles.map(a => a.link));
+        const changed =
+          articles.some(a => !lastLinks.has(a.link)) ||
+          [...lastLinks].some(l => !newLinks.has(l));
+        if (changed) {
+          lastLinks = newLinks;
+          enqueue(entry);
+        }
+      };
+
+      const interval = setInterval(poll, POLL_INTERVAL);
+
+      request.signal.addEventListener('abort', () => {
+        clearInterval(interval);
+        controller.close();
+      });
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+      'Content-Type': 'text/event-stream',
+    },
+  });
+}

--- a/apps/web/src/lib/news/cache.ts
+++ b/apps/web/src/lib/news/cache.ts
@@ -1,0 +1,43 @@
+export interface Article {
+  description: string;
+  link: string;
+  pubDate: string;
+  source: string;
+  timeAgo: string;
+  title: string;
+}
+
+export interface CacheEntry {
+  articles: Article[];
+  fetchedAt: number;
+}
+
+export const CACHE_TTL = 60_000;
+
+let globalCacheEntry: CacheEntry | null = null;
+const coinCacheMap = new Map<string, CacheEntry>();
+
+export function getGlobalCache(): CacheEntry | null {
+  return globalCacheEntry;
+}
+
+export function isGlobalCacheValid(): boolean {
+  return globalCacheEntry !== null && Date.now() - globalCacheEntry.fetchedAt < CACHE_TTL;
+}
+
+export function setGlobalCache(entry: CacheEntry): void {
+  globalCacheEntry = entry;
+}
+
+export function getCoinCache(coin: string): CacheEntry | null {
+  return coinCacheMap.get(coin) ?? null;
+}
+
+export function isCoinCacheValid(coin: string): boolean {
+  const entry = coinCacheMap.get(coin);
+  return entry !== undefined && Date.now() - entry.fetchedAt < CACHE_TTL;
+}
+
+export function setCoinCache(coin: string, entry: CacheEntry): void {
+  coinCacheMap.set(coin, entry);
+}

--- a/apps/web/src/lib/utils/coinFromInstrument.test.ts
+++ b/apps/web/src/lib/utils/coinFromInstrument.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { coinFromInstrument } from './coinFromInstrument';
+
+describe('coinFromInstrument', () => {
+  it('strips USDT suffix', () => {
+    expect(coinFromInstrument('SOLUSDT')).toBe('SOL');
+    expect(coinFromInstrument('BTCUSDT')).toBe('BTC');
+    expect(coinFromInstrument('ETHUSDT')).toBe('ETH');
+  });
+
+  it('strips BUSD suffix', () => {
+    expect(coinFromInstrument('BNBBUSD')).toBe('BNB');
+    expect(coinFromInstrument('ETHBUSD')).toBe('ETH');
+    expect(coinFromInstrument('SOLBUSD')).toBe('SOL');
+  });
+
+  it('strips BTC suffix', () => {
+    expect(coinFromInstrument('ETHBTC')).toBe('ETH');
+    expect(coinFromInstrument('SOLBTC')).toBe('SOL');
+    expect(coinFromInstrument('BNBBTC')).toBe('BNB');
+  });
+
+  it('strips ETH suffix', () => {
+    expect(coinFromInstrument('BNBETH')).toBe('BNB');
+    expect(coinFromInstrument('SOLETH')).toBe('SOL');
+  });
+
+  it('strips BNB suffix', () => {
+    expect(coinFromInstrument('ETHBNB')).toBe('ETH');
+    expect(coinFromInstrument('SOLBNB')).toBe('SOL');
+  });
+
+  it('returns the instrument unchanged when no known suffix matches', () => {
+    expect(coinFromInstrument('SOL')).toBe('SOL');
+    expect(coinFromInstrument('UNKNOWN')).toBe('UNKNOWN');
+    expect(coinFromInstrument('')).toBe('');
+  });
+});

--- a/apps/web/src/lib/utils/coinFromInstrument.ts
+++ b/apps/web/src/lib/utils/coinFromInstrument.ts
@@ -1,0 +1,14 @@
+const QUOTE_SUFFIXES = ['USDT', 'BUSD', 'BTC', 'ETH', 'BNB'] as const;
+
+/**
+ * Strips the quote currency suffix from a Binance instrument string.
+ * e.g. SOLUSDT → SOL, ETHBTC → ETH
+ */
+export function coinFromInstrument(instrument: string): string {
+  for (const suffix of QUOTE_SUFFIXES) {
+    if (instrument.endsWith(suffix)) {
+      return instrument.slice(0, instrument.length - suffix.length);
+    }
+  }
+  return instrument;
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,13 @@
+import path from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
Implements the crypto news SSE endpoints as specified in issue #25.

- `lib/utils/coinFromInstrument.ts` with unit tests
- `lib/news/cache.ts` shared in-memory cache
- `app/api/news/global/route.ts` global news SSE handler
- `app/api/news/coin/route.ts` coin-specific SSE handler

Closes #25

Generated with [Claude Code](https://claude.ai/code)