### PR TITLE
Publish closed candles to Redis Kline channel for downstream consumers

### DIFF
--- a/apps/binance-stream/.env.example
+++ b/apps/binance-stream/.env.example
@@ -7,3 +7,8 @@ HOST=0.0.0.0
 PORT=3001
 LOG_LEVEL=info
 CORS_ORIGINS=["http://localhost:3000"]
+
+# Redis Configuration
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_KLINE_CHANNEL=kline:closed

--- a/apps/binance-stream/README.md
+++ b/apps/binance-stream/README.md
@@ -8,6 +8,7 @@ Real-time WebSocket streamer for Binance USDS Futures market data, built with Fa
 - Exposes a WebSocket endpoint for the Next.js frontend
 - Seeds the last 3 closed candles from the REST API on startup
 - Broadcasts real-time tick and candle-close events to all connected clients
+- Publishes closed candle payloads to a Redis channel for downstream consumers (e.g. Pattern Analyzer)
 - Auto-reconnects to Binance with exponential backoff (1 s – 60 s)
 - FastAPI server with automatic OpenAPI documentation
 
@@ -15,6 +16,7 @@ Real-time WebSocket streamer for Binance USDS Futures market data, built with Fa
 
 - Python 3.12 (managed via pyenv)
 - Poetry for dependency management
+- Redis 6+ (for the kline channel publisher)
 
 ## Setup
 
@@ -60,6 +62,9 @@ All variables are optional — the defaults work for local development without B
 | `PORT` | `3001` | Server port |
 | `LOG_LEVEL` | `INFO` | Logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
 | `CORS_ORIGINS` | `["http://localhost:3000"]` | JSON array of allowed CORS origins |
+| `REDIS_HOST` | `localhost` | Redis server hostname |
+| `REDIS_PORT` | `6379` | Redis server port |
+| `REDIS_KLINE_CHANNEL` | `kline:closed` | Redis Pub/Sub channel for closed candle events |
 
 ## Endpoints
 
@@ -138,9 +143,41 @@ Binance USDS Futures
                ├── closed_candles  (last 3)
                └── current_candle
                           ↓
-                  broadcast to all connected
-                  frontend WebSocket clients
+               ┌──────────┴──────────┐
+               ↓                     ↓
+      broadcast to all          publish to Redis
+      connected frontend        kline:closed channel
+      WebSocket clients         (candle_closed events only)
 ```
+
+### Redis Channel
+
+On every 5-minute candle close, a JSON message is published to the `kline:closed` channel (configurable via `REDIS_KLINE_CHANNEL`). Downstream services (e.g. Pattern Analyzer) subscribe to this channel to receive closed candle data without going through the Application Layer.
+
+**Message format:**
+
+```json
+{
+  "type": "candle_closed",
+  "event_time": 1700000000000,
+  "pair": "BTCUSDT",
+  "contract_type": "PERPETUAL",
+  "kline": {
+    "open_time": 1700000000000,
+    "close_time": 1700000299999,
+    "interval": "5m",
+    "open": "42000.00",
+    "high": "42100.00",
+    "low": "41900.00",
+    "close": "42050.00",
+    "volume": "123.456",
+    "num_trades": 500,
+    "is_closed": true
+  }
+}
+```
+
+A Redis connection failure at startup logs a warning and disables publishing — the WebSocket stream and frontend broadcast continue unaffected.
 
 ### Key Modules
 
@@ -151,6 +188,7 @@ Binance USDS Futures
 | `src/connection_manager.py` | Manages frontend client connections and in-memory candle state |
 | `src/models.py` | `KlineData` / `KlineMessage` dataclasses and parse helpers |
 | `src/config.py` | `pydantic-settings` config loaded from `.env` |
+| `src/redis_publisher.py` | Redis connection lifecycle and closed candle publisher |
 
 ## Development
 

--- a/apps/binance-stream/pyproject.toml
+++ b/apps/binance-stream/pyproject.toml
@@ -13,7 +13,7 @@ uvicorn = { extras = ["standard"], version = "^0.34.0" }
 websockets = "^14.1"
 httpx = "^0.28.0"
 pydantic-settings = "^2.0.0"
-redis = { extras = ["asyncio"], version = "^5.0.0" }
+redis = { extras = ["asyncio"], version = "^7.0.0" }
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.8.0"

--- a/apps/binance-stream/pyproject.toml
+++ b/apps/binance-stream/pyproject.toml
@@ -13,6 +13,7 @@ uvicorn = { extras = ["standard"], version = "^0.34.0" }
 websockets = "^14.1"
 httpx = "^0.28.0"
 pydantic-settings = "^2.0.0"
+redis = { extras = ["asyncio"], version = "^5.0.0" }
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.8.0"

--- a/apps/binance-stream/src/config.py
+++ b/apps/binance-stream/src/config.py
@@ -18,6 +18,9 @@ class Settings(BaseSettings):
     port: int = 3001
     binance_api_key: str = ""
     binance_api_secret: str = ""
+    redis_host: str = "localhost"
+    redis_port: int = 6379
+    redis_kline_channel: str = "kline:closed"
 
 
 settings = Settings()

--- a/apps/binance-stream/src/main.py
+++ b/apps/binance-stream/src/main.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel
 from .config import settings
 from .connection_manager import ConnectionManager
 from .stream import fetch_initial_candles, run_binance_stream
+from . import redis_publisher
 
 
 class HealthResponse(BaseModel):
@@ -39,6 +40,8 @@ TRACKED_PAIRS = ["btcusdt"]
 
 @asynccontextmanager
 async def lifespan(_: FastAPI):
+    await redis_publisher.connect()
+
     for pair in TRACKED_PAIRS:
         try:
             _managers[pair] = ConnectionManager()
@@ -61,6 +64,8 @@ async def lifespan(_: FastAPI):
     if _stream_tasks:
         await asyncio.gather(*_stream_tasks.values(), return_exceptions=True)
     logger.info("All stream tasks stopped")
+
+    await redis_publisher.close()
 
 
 app = FastAPI(

--- a/apps/binance-stream/src/redis_publisher.py
+++ b/apps/binance-stream/src/redis_publisher.py
@@ -9,20 +9,20 @@ the caller — a Redis failure must not interrupt the WebSocket stream.
 import json
 import logging
 
-import redis.asyncio as aioredis
+from redis.asyncio import Redis
 
 from .config import settings
 
 logger = logging.getLogger(__name__)
 
-_redis: aioredis.Redis | None = None
+_redis: Redis | None = None
 
 
 async def connect() -> None:
     """Open the Redis connection. Called during FastAPI lifespan startup."""
     global _redis
     try:
-        _redis = aioredis.Redis(
+        _redis = Redis(
             host=settings.redis_host,
             port=settings.redis_port,
             decode_responses=True,

--- a/apps/binance-stream/src/redis_publisher.py
+++ b/apps/binance-stream/src/redis_publisher.py
@@ -1,0 +1,66 @@
+"""
+Redis publisher for closed candle events.
+
+Manages the Redis connection lifecycle and publishes closed candle payloads
+to the configured kline channel. Errors are logged and never propagated to
+the caller — a Redis failure must not interrupt the WebSocket stream.
+"""
+
+import json
+import logging
+
+import redis.asyncio as aioredis
+
+from .config import settings
+
+logger = logging.getLogger(__name__)
+
+_redis: aioredis.Redis | None = None
+
+
+async def connect() -> None:
+    """Open the Redis connection. Called during FastAPI lifespan startup."""
+    global _redis
+    try:
+        _redis = aioredis.Redis(
+            host=settings.redis_host,
+            port=settings.redis_port,
+            decode_responses=True,
+        )
+        await _redis.ping()
+        logger.info(
+            "Redis connected: %s:%d (channel: %s)",
+            settings.redis_host,
+            settings.redis_port,
+            settings.redis_kline_channel,
+        )
+    except Exception:
+        logger.warning(
+            "Redis connection failed (%s:%d) — candle publishing disabled",
+            settings.redis_host,
+            settings.redis_port,
+            exc_info=True,
+        )
+        _redis = None
+
+
+async def close() -> None:
+    """Close the Redis connection. Called during FastAPI lifespan shutdown."""
+    global _redis
+    if _redis is not None:
+        await _redis.aclose()
+        _redis = None
+        logger.info("Redis connection closed")
+
+
+async def publish_closed_candle(candle_dict: dict) -> None:
+    """Publish a closed candle payload to the Redis kline channel.
+
+    Fire-and-forget: errors are logged but never re-raised.
+    """
+    if _redis is None:
+        return
+    try:
+        await _redis.publish(settings.redis_kline_channel, json.dumps(candle_dict))
+    except Exception:
+        logger.error("Failed to publish closed candle to Redis", exc_info=True)

--- a/apps/binance-stream/src/stream.py
+++ b/apps/binance-stream/src/stream.py
@@ -16,6 +16,7 @@ from websockets.exceptions import ConnectionClosed
 
 from .connection_manager import ConnectionManager
 from .models import kline_message_to_dict, parse_kline_message
+from . import redis_publisher
 
 logger = logging.getLogger(__name__)
 
@@ -91,7 +92,9 @@ async def _handle_message(raw_text: str, cm: ConnectionManager) -> None:
     candle_dict = kline_message_to_dict(msg)
     if msg.kline.is_closed:
         cm.update_closed_candle(candle_dict)
-        await cm.broadcast({**candle_dict, "type": "candle_closed"})
+        closed_payload = {**candle_dict, "type": "candle_closed"}
+        await cm.broadcast(closed_payload)
+        await redis_publisher.publish_closed_candle(closed_payload)
     else:
         cm.update_current_candle(candle_dict)
         await cm.broadcast({**candle_dict, "type": "tick"})


### PR DESCRIPTION
Extends `binance-stream` to publish `candle_closed` payloads to a Redis Pub/Sub channel whenever a 5-minute candle closes, enabling downstream consumers (e.g. Pattern Analyzer) to receive kline data without going through the Next.js application layer.

Closes #27

Generated with [Claude Code](https://claude.ai/code)