### PR TITLE
Add instrument-registry service with sync capabilities and endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This is a **pnpm workspace monorepo** containing:
 - **`apps/web/`** — Next.js 16 frontend (React 19, Tailwind CSS v4, TypeScript)
 - **`apps/binance-stream/`** — Python WebSocket streamer (FastAPI, Binance USDS Futures)
 - **`apps/candle-collector/`** — Node.js service that fetches historical OHLC data from CoinDesk and stores it in PostgreSQL
+- **`apps/instrument-registry/`** — Node.js service that syncs tradable instrument data from Binance and stores it in PostgreSQL
 - **`packages/types/`** — Shared TypeScript types (future use)
 
 ### Data Flow
@@ -29,6 +30,13 @@ CoinDesk API (REST)
 apps/candle-collector (Fastify + Node.js)  ← triggered manually via HTTP
     ↓
 PostgreSQL (historical OHLC candles)
+
+Binance USDS Futures REST API
+    ↓
+apps/instrument-registry (Fastify + Node.js)  ← periodic cron sync + manual trigger
+    ↓
+    ├─→ PostgreSQL (instruments table)
+    └─→ Redis (exchange:instruments channel — change events)
 ```
 
 ## Prerequisites
@@ -36,7 +44,8 @@ PostgreSQL (historical OHLC candles)
 - **Node.js** 20+ and **pnpm** 9+
 - **Python** 3.12 (via [pyenv](https://github.com/pyenv/pyenv))
 - **Poetry** ([installation guide](https://python-poetry.org/docs/#installation))
-- **PostgreSQL** (required by `candle-collector`)
+- **PostgreSQL** (required by `candle-collector` and `instrument-registry`)
+- **Redis** (required by `instrument-registry`)
 
 ## Quick Start
 
@@ -68,6 +77,10 @@ cp apps/binance-stream/.env.example apps/binance-stream/.env
 # Candle collector (requires PostgreSQL + CoinDesk API key)
 cp apps/candle-collector/.env.example apps/candle-collector/.env
 # Edit .env with your DATABASE_URL and COINDESK_API_KEY
+
+# Instrument registry (requires PostgreSQL + Redis)
+cp apps/instrument-registry/.env.example apps/instrument-registry/.env
+# Edit .env with your DATABASE_URL, REDIS_HOST, REDIS_PORT, and BINANCE_REST_BASE_URL
 ```
 
 ### 3. Run Development Servers
@@ -95,11 +108,13 @@ pnpm dev:stream
 ### Monorepo (Root)
 
 ```bash
-pnpm dev                    # Run web + binance-stream in parallel
-pnpm dev:web                # Run Next.js app only
-pnpm dev:stream             # Run Python streamer only
-pnpm dev:candle-collector   # Run candle-collector only
-pnpm start:candle-collector # Run candle-collector in production mode
+pnpm dev                        # Run web + binance-stream in parallel
+pnpm dev:web                    # Run Next.js app only
+pnpm dev:stream                 # Run Python streamer only
+pnpm dev:candle-collector       # Run candle-collector only
+pnpm start:candle-collector     # Run candle-collector in production mode
+pnpm dev:instrument-registry    # Run instrument-registry only
+pnpm start:instrument-registry  # Run instrument-registry in production mode
 ```
 
 ### Next.js App (`apps/web/`)
@@ -140,6 +155,17 @@ pnpm dev            # Start dev server with hot reload (localhost:3002)
 pnpm start          # Start production server
 ```
 
+### Instrument Registry (`apps/instrument-registry/`)
+
+```bash
+cd apps/instrument-registry
+pnpm install        # Install dependencies
+pnpm db:generate    # Generate DB migration (after schema changes)
+pnpm db:migrate     # Apply pending migrations
+pnpm dev            # Start dev server with hot reload (localhost:3003)
+pnpm start          # Start production server
+```
+
 ## Tech Stack
 
 ### Frontend (`apps/web/`)
@@ -168,6 +194,16 @@ pnpm start          # Start production server
 - **Database:** PostgreSQL via Drizzle ORM
 - **Package Manager:** pnpm
 
+### Instrument Registry (`apps/instrument-registry/`)
+
+- **Framework:** Fastify v5 (Node.js)
+- **Language:** TypeScript (ESM)
+- **Data Source:** Binance USDS Futures REST API
+- **Database:** PostgreSQL via Drizzle ORM
+- **Cache/Pubsub:** Redis (ioredis)
+- **Scheduling:** node-cron
+- **Package Manager:** pnpm
+
 ## Project Structure
 
 ```
@@ -190,14 +226,24 @@ crypto-terminal/
 │   │   │   ├── models.py     # Kline data models
 │   │   │   └── config.py     # Environment settings
 │   │   └── pyproject.toml
-│   └── candle-collector/     # Node.js historical OHLC collector
+│   ├── candle-collector/     # Node.js historical OHLC collector
+│   │   ├── src/
+│   │   │   ├── server.ts     # Fastify server entry point
+│   │   │   ├── app.ts        # App factory
+│   │   │   ├── config.ts     # Environment settings
+│   │   │   ├── db/           # Drizzle schema, client, migrations
+│   │   │   ├── plugins/      # Fastify plugins (postgres, coindesk)
+│   │   │   └── routes/       # HTTP route handlers
+│   │   └── package.json
+│   └── instrument-registry/  # Node.js instrument sync service
 │       ├── src/
 │       │   ├── server.ts     # Fastify server entry point
 │       │   ├── app.ts        # App factory
 │       │   ├── config.ts     # Environment settings
 │       │   ├── db/           # Drizzle schema, client, migrations
-│       │   ├── plugins/      # Fastify plugins (postgres, coindesk)
-│       │   └── routes/       # HTTP route handlers
+│       │   ├── plugins/      # Fastify plugins (postgres, redis, sync)
+│       │   ├── routes/       # HTTP route handlers
+│       │   └── services/     # Binance REST client, sync logic
 │       └── package.json
 ├── packages/
 │   └── types/                # Shared TypeScript types (future use)

--- a/apps/instrument-registry/.env.example
+++ b/apps/instrument-registry/.env.example
@@ -1,0 +1,24 @@
+# Port the service listens on — optional, defaults to 3003
+PORT=3003
+
+# Pino log level — optional, defaults to info
+# Options: trace, debug, info, warn, error, fatal
+LOG_LEVEL=info
+
+# PostgreSQL connection string — required
+# Format: postgres://user:password@host:port/database
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/crypto_terminal
+
+# Redis connection — required
+REDIS_HOST=localhost
+REDIS_PORT=6379
+
+# Redis channel for instrument change events — optional, defaults to exchange:instruments
+REDIS_INSTRUMENTS_CHANNEL=exchange:instruments
+
+# Binance USDS Futures REST API base URL — required
+BINANCE_REST_BASE_URL=https://fapi.binance.com
+
+# Cron expression for periodic sync — optional, defaults to every 24 hours at midnight
+# Examples: "0 0 * * *" (daily midnight), "0 */6 * * *" (every 6 hours)
+SYNC_CRON=0 0 * * *

--- a/apps/instrument-registry/drizzle.config.ts
+++ b/apps/instrument-registry/drizzle.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'drizzle-kit';
+
+export default defineConfig({
+  schema: './src/db/schema.ts',
+  out: './src/db/migrations',
+  dialect: 'postgresql',
+  dbCredentials: {
+    url: process.env.DATABASE_URL!,
+  },
+});

--- a/apps/instrument-registry/package.json
+++ b/apps/instrument-registry/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "instrument-registry",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Periodically syncs tradable instrument data from Binance USDS Futures and stores in PostgreSQL",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/server.ts",
+    "start": "node dist/server.js",
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate"
+  },
+  "dependencies": {
+    "drizzle-orm": "^0.40.0",
+    "fastify": "^5.2.1",
+    "fastify-plugin": "^5.0.1",
+    "ioredis": "^5.4.2",
+    "node-cron": "^3.0.3",
+    "pg": "^8.13.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/node-cron": "^3.0.11",
+    "@types/pg": "^8.11.0",
+    "drizzle-kit": "^0.30.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/apps/instrument-registry/src/app.ts
+++ b/apps/instrument-registry/src/app.ts
@@ -1,0 +1,29 @@
+import Fastify from 'fastify';
+import { config } from './config.js';
+import postgresPlugin from './plugins/postgres.js';
+import redisPlugin from './plugins/redis.js';
+import syncPlugin from './plugins/sync.js';
+import { instrumentRoutes } from './routes/instruments/index.js';
+
+export async function buildApp() {
+  const fastify = Fastify({
+    logger: {
+      level: config.logLevel,
+    },
+  });
+
+  // Infrastructure plugins
+  await fastify.register(postgresPlugin);
+  await fastify.register(redisPlugin);
+
+  // Sync plugin — registers triggerSync decorator and sets up cron + startup sync
+  await fastify.register(syncPlugin);
+
+  // Health check
+  fastify.get('/health', async () => ({ status: 'ok' }));
+
+  // Routes
+  await fastify.register(instrumentRoutes);
+
+  return fastify;
+}

--- a/apps/instrument-registry/src/config.ts
+++ b/apps/instrument-registry/src/config.ts
@@ -1,0 +1,27 @@
+const required = ['DATABASE_URL', 'REDIS_HOST', 'REDIS_PORT', 'BINANCE_REST_BASE_URL'] as const;
+
+for (const key of required) {
+  if (!process.env[key]) {
+    console.error(`[config] Missing required environment variable: ${key}`);
+    process.exit(1);
+  }
+}
+
+export const config = {
+  database: {
+    url: process.env.DATABASE_URL as string,
+  },
+  redis: {
+    host: process.env.REDIS_HOST as string,
+    port: parseInt(process.env.REDIS_PORT as string, 10),
+    instrumentsChannel: process.env.REDIS_INSTRUMENTS_CHANNEL ?? 'exchange:instruments',
+  },
+  binance: {
+    restBaseUrl: process.env.BINANCE_REST_BASE_URL as string,
+  },
+  sync: {
+    cron: process.env.SYNC_CRON ?? '0 0 * * *',
+  },
+  port: parseInt(process.env.PORT ?? '3003', 10),
+  logLevel: process.env.LOG_LEVEL ?? 'info',
+};

--- a/apps/instrument-registry/src/db/client.ts
+++ b/apps/instrument-registry/src/db/client.ts
@@ -1,0 +1,9 @@
+import { drizzle } from 'drizzle-orm/node-postgres';
+import type pg from 'pg';
+import * as schema from './schema';
+
+export function createDb(pool: pg.Pool) {
+  return drizzle(pool, { schema });
+}
+
+export type Db = ReturnType<typeof createDb>;

--- a/apps/instrument-registry/src/db/migrations/0000_create_instruments.sql
+++ b/apps/instrument-registry/src/db/migrations/0000_create_instruments.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "instruments" (
+	"symbol" varchar(50) PRIMARY KEY NOT NULL,
+	"pair" varchar(50) NOT NULL,
+	"contract_type" varchar(50) NOT NULL,
+	"delivery_date" bigint NOT NULL,
+	"status" varchar(50) NOT NULL,
+	"last_synced_at" timestamp NOT NULL
+);

--- a/apps/instrument-registry/src/db/migrations/meta/_journal.json
+++ b/apps/instrument-registry/src/db/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1742544000000,
+      "tag": "0000_create_instruments",
+      "breakpoints": true
+    }
+  ]
+}

--- a/apps/instrument-registry/src/db/schema.ts
+++ b/apps/instrument-registry/src/db/schema.ts
@@ -1,0 +1,13 @@
+import { bigint, pgTable, timestamp, varchar } from 'drizzle-orm/pg-core';
+
+export const instruments = pgTable('instruments', {
+  symbol: varchar('symbol', { length: 50 }).primaryKey(),
+  pair: varchar('pair', { length: 50 }).notNull(),
+  contractType: varchar('contract_type', { length: 50 }).notNull(),
+  deliveryDate: bigint('delivery_date', { mode: 'number' }).notNull(),
+  status: varchar('status', { length: 50 }).notNull(),
+  lastSyncedAt: timestamp('last_synced_at').notNull(),
+});
+
+export type Instrument = typeof instruments.$inferSelect;
+export type NewInstrument = typeof instruments.$inferInsert;

--- a/apps/instrument-registry/src/plugins/postgres.ts
+++ b/apps/instrument-registry/src/plugins/postgres.ts
@@ -1,0 +1,36 @@
+import fp from 'fastify-plugin';
+import type { FastifyInstance } from 'fastify';
+import pg from 'pg';
+import { createDb, type Db } from '../db/client.js';
+import { config } from '../config.js';
+
+const { Pool } = pg;
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    db: Db;
+  }
+}
+
+async function postgresPlugin(fastify: FastifyInstance): Promise<void> {
+  const pool = new Pool({ connectionString: config.database.url });
+
+  try {
+    const client = await pool.connect();
+    await client.query('SELECT 1');
+    client.release();
+    fastify.log.info('[postgres] Database connection established');
+  } catch (err) {
+    fastify.log.error({ err }, '[postgres] Failed to connect to database');
+    process.exit(1);
+  }
+
+  fastify.decorate('db', createDb(pool));
+
+  fastify.addHook('onClose', async () => {
+    await pool.end();
+    fastify.log.info('[postgres] Connection pool closed');
+  });
+}
+
+export default fp(postgresPlugin, { name: 'postgres' });

--- a/apps/instrument-registry/src/plugins/redis.ts
+++ b/apps/instrument-registry/src/plugins/redis.ts
@@ -1,0 +1,76 @@
+import fp from 'fastify-plugin';
+import type { FastifyInstance } from 'fastify';
+import Redis from 'ioredis';
+import { config } from '../config.js';
+
+export interface InstrumentChangePayload {
+  newListings: string[];
+  delistings: string[];
+  upcomingDelistings: Array<{ symbol: string; deliveryDate: number }>;
+  updates: string[];
+}
+
+interface InstrumentChangeEvent extends InstrumentChangePayload {
+  type: 'instruments_changed';
+  timestamp: number;
+}
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    redis: {
+      publishInstrumentChanges: (payload: InstrumentChangePayload) => Promise<void>;
+    };
+  }
+}
+
+async function redisPlugin(fastify: FastifyInstance): Promise<void> {
+  const client = new Redis({
+    host: config.redis.host,
+    port: config.redis.port,
+    lazyConnect: true,
+  });
+
+  client.on('error', (err) => {
+    fastify.log.error({ err }, '[redis] Connection error');
+  });
+
+  try {
+    await client.connect();
+    fastify.log.info('[redis] Connected to %s:%d', config.redis.host, config.redis.port);
+  } catch (err) {
+    fastify.log.error({ err }, '[redis] Failed to connect');
+    process.exit(1);
+  }
+
+  async function publishInstrumentChanges(payload: InstrumentChangePayload): Promise<void> {
+    const event: InstrumentChangeEvent = {
+      type: 'instruments_changed',
+      timestamp: Date.now(),
+      ...payload,
+    };
+    try {
+      await client.publish(config.redis.instrumentsChannel, JSON.stringify(event));
+      fastify.log.info(
+        {
+          newListings: payload.newListings.length,
+          delistings: payload.delistings.length,
+          upcomingDelistings: payload.upcomingDelistings.length,
+          updates: payload.updates.length,
+        },
+        '[redis] Published instrument changes to %s',
+        config.redis.instrumentsChannel,
+      );
+    } catch (err) {
+      fastify.log.error({ err }, '[redis] Failed to publish instrument changes');
+    }
+  }
+
+  fastify.decorate('redis', { publishInstrumentChanges });
+
+  fastify.addHook('onClose', async () => {
+    await client.quit();
+    fastify.log.info('[redis] Connection closed');
+  });
+}
+
+export default fp(redisPlugin, { name: 'redis' });

--- a/apps/instrument-registry/src/plugins/sync.ts
+++ b/apps/instrument-registry/src/plugins/sync.ts
@@ -1,0 +1,59 @@
+import fp from 'fastify-plugin';
+import type { FastifyInstance } from 'fastify';
+import cron from 'node-cron';
+import { config } from '../config.js';
+import { syncInstruments } from '../services/sync.js';
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    triggerSync: () => Promise<void>;
+  }
+}
+
+async function syncPlugin(fastify: FastifyInstance): Promise<void> {
+  let syncInProgress = false;
+
+  async function triggerSync(): Promise<void> {
+    if (syncInProgress) {
+      fastify.log.warn('[sync] Sync already in progress, skipping');
+      return;
+    }
+
+    syncInProgress = true;
+    try {
+      await syncInstruments(fastify.db, fastify.redis, config.binance.restBaseUrl, fastify.log);
+    } finally {
+      syncInProgress = false;
+    }
+  }
+
+  fastify.decorate('triggerSync', triggerSync);
+
+  // Run initial sync after server is ready
+  fastify.addHook('onReady', async () => {
+    fastify.log.info('[sync] Running initial sync on startup');
+    try {
+      await triggerSync();
+      fastify.log.info('[sync] Initial sync complete');
+    } catch (err) {
+      fastify.log.error({ err }, '[sync] Initial sync failed');
+    }
+  });
+
+  // Schedule periodic sync
+  const task = cron.schedule(config.sync.cron, async () => {
+    fastify.log.info('[sync] Running scheduled sync (cron: %s)', config.sync.cron);
+    try {
+      await triggerSync();
+    } catch (err) {
+      fastify.log.error({ err }, '[sync] Scheduled sync failed');
+    }
+  });
+
+  fastify.addHook('onClose', async () => {
+    task.stop();
+    fastify.log.info('[sync] Cron task stopped');
+  });
+}
+
+export default fp(syncPlugin, { name: 'sync', dependencies: ['postgres', 'redis'] });

--- a/apps/instrument-registry/src/routes/instruments/handler.ts
+++ b/apps/instrument-registry/src/routes/instruments/handler.ts
@@ -1,0 +1,71 @@
+import { eq } from 'drizzle-orm';
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import { instruments } from '../../db/schema.js';
+import { syncInstruments } from '../../services/sync.js';
+import { config } from '../../config.js';
+
+// In-progress lock for manual sync triggers
+let manualSyncInProgress = false;
+
+export async function getInstrumentsHandler(
+  _request: FastifyRequest,
+  reply: FastifyReply,
+): Promise<void> {
+  const result = await reply.server.db.select().from(instruments);
+  return reply.send(result);
+}
+
+export async function getInstrumentBySymbolHandler(
+  request: FastifyRequest<{ Params: { symbol: string } }>,
+  reply: FastifyReply,
+): Promise<void> {
+  const { symbol } = request.params;
+  const result = await reply.server.db
+    .select()
+    .from(instruments)
+    .where(eq(instruments.symbol, symbol.toUpperCase()))
+    .limit(1);
+
+  if (result.length === 0) {
+    return reply.code(404).send({
+      statusCode: 404,
+      error: 'Not Found',
+      message: `Instrument "${symbol.toUpperCase()}" not found`,
+    });
+  }
+
+  return reply.send(result[0]);
+}
+
+export async function syncInstrumentsHandler(
+  request: FastifyRequest,
+  reply: FastifyReply,
+): Promise<void> {
+  if (manualSyncInProgress) {
+    return reply.code(409).send({
+      statusCode: 409,
+      error: 'Conflict',
+      message: 'A sync is already in progress',
+    });
+  }
+
+  manualSyncInProgress = true;
+  try {
+    const result = await syncInstruments(
+      request.server.db,
+      request.server.redis,
+      config.binance.restBaseUrl,
+      request.log,
+    );
+    return reply.send({ status: 'ok', ...result });
+  } catch (err) {
+    request.log.error({ err }, '[sync] Manual sync failed');
+    return reply.code(500).send({
+      statusCode: 500,
+      error: 'Internal Server Error',
+      message: 'Sync failed',
+    });
+  } finally {
+    manualSyncInProgress = false;
+  }
+}

--- a/apps/instrument-registry/src/routes/instruments/index.ts
+++ b/apps/instrument-registry/src/routes/instruments/index.ts
@@ -1,0 +1,21 @@
+import type { FastifyInstance } from 'fastify';
+import {
+  getInstrumentBySymbolHandler,
+  getInstrumentsHandler,
+  syncInstrumentsHandler,
+} from './handler.js';
+import {
+  getInstrumentBySymbolSchema,
+  getInstrumentsSchema,
+  syncInstrumentsSchema,
+} from './schema.js';
+
+export async function instrumentRoutes(fastify: FastifyInstance): Promise<void> {
+  fastify.get('/instruments', { schema: getInstrumentsSchema }, getInstrumentsHandler);
+  fastify.get(
+    '/instruments/:symbol',
+    { schema: getInstrumentBySymbolSchema },
+    getInstrumentBySymbolHandler,
+  );
+  fastify.post('/instruments/sync', { schema: syncInstrumentsSchema }, syncInstrumentsHandler);
+}

--- a/apps/instrument-registry/src/routes/instruments/schema.ts
+++ b/apps/instrument-registry/src/routes/instruments/schema.ts
@@ -1,0 +1,60 @@
+const instrumentSchema = {
+  type: 'object',
+  properties: {
+    symbol: { type: 'string' },
+    pair: { type: 'string' },
+    contractType: { type: 'string' },
+    deliveryDate: { type: 'number' },
+    status: { type: 'string' },
+    lastSyncedAt: { type: 'string' },
+  },
+};
+
+const errorSchema = {
+  type: 'object',
+  properties: {
+    statusCode: { type: 'integer' },
+    error: { type: 'string' },
+    message: { type: 'string' },
+  },
+};
+
+export const getInstrumentsSchema = {
+  response: {
+    200: {
+      type: 'array',
+      items: instrumentSchema,
+    },
+  },
+};
+
+export const getInstrumentBySymbolSchema = {
+  params: {
+    type: 'object',
+    required: ['symbol'],
+    properties: {
+      symbol: { type: 'string' },
+    },
+  },
+  response: {
+    200: instrumentSchema,
+    404: errorSchema,
+  },
+};
+
+export const syncInstrumentsSchema = {
+  response: {
+    200: {
+      type: 'object',
+      properties: {
+        status: { type: 'string' },
+        newListings: { type: 'integer' },
+        delistings: { type: 'integer' },
+        upcomingDelistings: { type: 'integer' },
+        updates: { type: 'integer' },
+      },
+    },
+    409: errorSchema,
+    500: errorSchema,
+  },
+};

--- a/apps/instrument-registry/src/server.ts
+++ b/apps/instrument-registry/src/server.ts
@@ -1,0 +1,11 @@
+import { config } from './config.js';
+import { buildApp } from './app.js';
+
+const fastify = await buildApp();
+
+try {
+  await fastify.listen({ port: config.port, host: '0.0.0.0' });
+} catch (err) {
+  fastify.log.error(err);
+  process.exit(1);
+}

--- a/apps/instrument-registry/src/services/binance.ts
+++ b/apps/instrument-registry/src/services/binance.ts
@@ -1,0 +1,23 @@
+export interface BinanceSymbol {
+  symbol: string;
+  pair: string;
+  contractType: string;
+  deliveryDate: number;
+  status: string;
+}
+
+interface BinanceExchangeInfoResponse {
+  symbols: BinanceSymbol[];
+}
+
+export async function fetchExchangeInfo(baseUrl: string): Promise<BinanceSymbol[]> {
+  const url = `${baseUrl}/fapi/v1/exchangeInfo`;
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`Binance REST API returned HTTP ${response.status} for ${url}`);
+  }
+
+  const data: BinanceExchangeInfoResponse = await response.json();
+  return data.symbols;
+}

--- a/apps/instrument-registry/src/services/sync.ts
+++ b/apps/instrument-registry/src/services/sync.ts
@@ -1,0 +1,146 @@
+import { inArray, sql } from 'drizzle-orm';
+import type { FastifyBaseLogger } from 'fastify';
+import type { Db } from '../db/client.js';
+import { instruments, type NewInstrument } from '../db/schema.js';
+import { fetchExchangeInfo } from './binance.js';
+import type { InstrumentChangePayload } from '../plugins/redis.js';
+
+// Symbols whose deliveryDate falls within this window are flagged as upcoming delistings.
+const UPCOMING_DELISTING_WINDOW_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+interface SyncResult {
+  newListings: number;
+  delistings: number;
+  upcomingDelistings: number;
+  updates: number;
+}
+
+export async function syncInstruments(
+  db: Db,
+  publisher: { publishInstrumentChanges: (payload: InstrumentChangePayload) => Promise<void> },
+  binanceBaseUrl: string,
+  log: FastifyBaseLogger,
+): Promise<SyncResult> {
+  log.info('[sync] Fetching exchange info from Binance');
+  const allSymbols = await fetchExchangeInfo(binanceBaseUrl);
+
+  // Filter to PERPETUAL contracts only
+  const perpetuals = allSymbols.filter((s) => s.contractType === 'PERPETUAL');
+  log.info('[sync] Fetched %d PERPETUAL symbols from Binance', perpetuals.length);
+
+  // Load current DB state
+  const existing = await db.select().from(instruments);
+  const existingMap = new Map(existing.map((i) => [i.symbol, i]));
+  const incomingMap = new Map(perpetuals.map((s) => [s.symbol, s]));
+
+  const now = Date.now();
+  const delistingThreshold = now + UPCOMING_DELISTING_WINDOW_MS;
+
+  const newListings: string[] = [];
+  const updatedSymbols: string[] = [];
+  const upcomingDelistings: Array<{ symbol: string; deliveryDate: number }> = [];
+  const removedSymbols: string[] = [];
+
+  // Detect new and updated symbols
+  for (const [symbol, incoming] of incomingMap) {
+    const current = existingMap.get(symbol);
+
+    if (!current) {
+      newListings.push(symbol);
+      // New symbol with near-future delivery date is an upcoming delisting
+      if (incoming.deliveryDate > now && incoming.deliveryDate < delistingThreshold) {
+        upcomingDelistings.push({ symbol, deliveryDate: incoming.deliveryDate });
+      }
+    } else {
+      const hasChanges =
+        current.status !== incoming.status ||
+        current.deliveryDate !== incoming.deliveryDate ||
+        current.contractType !== incoming.contractType ||
+        current.pair !== incoming.pair;
+
+      if (hasChanges) {
+        updatedSymbols.push(symbol);
+        // Delivery date updated to near future signals an upcoming delisting
+        if (incoming.deliveryDate > now && incoming.deliveryDate < delistingThreshold) {
+          upcomingDelistings.push({ symbol, deliveryDate: incoming.deliveryDate });
+        }
+      }
+    }
+  }
+
+  // Detect removed symbols
+  for (const symbol of existingMap.keys()) {
+    if (!incomingMap.has(symbol)) {
+      removedSymbols.push(symbol);
+    }
+  }
+
+  log.info(
+    {
+      newListings: newListings.length,
+      updates: updatedSymbols.length,
+      delistings: removedSymbols.length,
+      upcomingDelistings: upcomingDelistings.length,
+    },
+    '[sync] Diff complete',
+  );
+
+  // Upsert new and changed symbols
+  const syncTime = new Date();
+  const toUpsert: NewInstrument[] = [...newListings, ...updatedSymbols].map((symbol) => {
+    const s = incomingMap.get(symbol)!;
+    return {
+      symbol: s.symbol,
+      pair: s.pair,
+      contractType: s.contractType,
+      deliveryDate: s.deliveryDate,
+      status: s.status,
+      lastSyncedAt: syncTime,
+    };
+  });
+
+  if (toUpsert.length > 0) {
+    await db
+      .insert(instruments)
+      .values(toUpsert)
+      .onConflictDoUpdate({
+        target: instruments.symbol,
+        set: {
+          pair: sql`excluded.pair`,
+          contractType: sql`excluded.contract_type`,
+          deliveryDate: sql`excluded.delivery_date`,
+          status: sql`excluded.status`,
+          lastSyncedAt: sql`excluded.last_synced_at`,
+        },
+      });
+    log.info('[sync] Upserted %d instruments', toUpsert.length);
+  }
+
+  // Delete removed symbols
+  if (removedSymbols.length > 0) {
+    await db.delete(instruments).where(inArray(instruments.symbol, removedSymbols));
+    log.info('[sync] Deleted %d removed instruments', removedSymbols.length);
+  }
+
+  // Publish change event if anything changed
+  const hasChanges =
+    newListings.length > 0 || removedSymbols.length > 0 || updatedSymbols.length > 0;
+
+  if (hasChanges) {
+    await publisher.publishInstrumentChanges({
+      newListings,
+      delistings: removedSymbols,
+      upcomingDelistings,
+      updates: updatedSymbols,
+    });
+  } else {
+    log.info('[sync] No changes detected, skipping Redis publish');
+  }
+
+  return {
+    newListings: newListings.length,
+    delistings: removedSymbols.length,
+    upcomingDelistings: upcomingDelistings.length,
+    updates: updatedSymbols.length,
+  };
+}

--- a/apps/instrument-registry/tsconfig.json
+++ b/apps/instrument-registry/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "dev:stream": "cd apps/binance-stream && poetry run uvicorn src.main:app --reload --host 0.0.0.0 --port 3001",
     "dev:candle-collector": "pnpm --filter candle-collector dev",
     "start:candle-collector": "pnpm --filter candle-collector start",
+    "dev:instrument-registry": "pnpm --filter instrument-registry dev",
+    "start:instrument-registry": "pnpm --filter instrument-registry start",
     "build:web": "pnpm --filter web build",
     "start:web": "pnpm --filter web start",
     "lint:web": "pnpm --filter web lint",


### PR DESCRIPTION
Implements the `instrument-registry` service as described in #29.

## Changes

- Scaffolded `apps/instrument-registry` as a standalone Fastify service
- Drizzle ORM schema for instruments table
- Periodic sync from Binance USDS Futures REST API (configurable cron)
- Diff logic: new listings, field changes, removals, upcoming delistings
- Redis publish to `exchange:instruments` channel on any changes
- HTTP endpoints: GET /instruments, GET /instruments/:symbol, POST /instruments/sync, GET /health
- Root `package.json` scripts and `README.md` updated

Closes #29

Generated with [Claude Code](https://claude.ai/code)