### PR TITLE
Integrate instrument-registry backend with Redis support and API

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,2 +1,10 @@
 # Binance Stream WebSocket
 NEXT_PUBLIC_WS_URL=ws://localhost:3001/ws
+
+# Instrument Registry Service
+INSTRUMENT_REGISTRY_URL=http://localhost:3003
+
+# Redis (for subscribing to instrument change events)
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_INSTRUMENTS_CHANNEL=exchange:instruments

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "@tanstack/react-query": "^5.90.21",
+    "ioredis": "^5.4.2",
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3"

--- a/apps/web/src/app/api/instruments/stream/route.ts
+++ b/apps/web/src/app/api/instruments/stream/route.ts
@@ -1,0 +1,61 @@
+import { applyInstrumentChanges } from '@/lib/instruments/registry';
+import { INSTRUMENTS_CHANNEL, createRedisSubscriber } from '@/lib/redis';
+
+export async function GET(request: Request): Promise<Response> {
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      const redis = createRedisSubscriber();
+
+      redis.on('error', (err) => {
+        console.error('[instruments/stream] Redis error:', err);
+      });
+
+      try {
+        await redis.connect();
+      } catch (err) {
+        console.error('[instruments/stream] Failed to connect to Redis:', err);
+        controller.close();
+        return;
+      }
+
+      redis.on('message', (_channel: string, message: string) => {
+        try {
+          const event = JSON.parse(message) as {
+            type: string;
+            newListings?: string[];
+            delistings?: string[];
+          };
+
+          if (event.type === 'instruments_changed') {
+            applyInstrumentChanges({
+              newListings: event.newListings ?? [],
+              delistings: event.delistings ?? [],
+            });
+          }
+
+          controller.enqueue(encoder.encode(`data: ${message}\n\n`));
+        } catch (err) {
+          console.error('[instruments/stream] Failed to parse Redis message:', err);
+        }
+      });
+
+      await redis.subscribe(INSTRUMENTS_CHANNEL);
+
+      request.signal.addEventListener('abort', async () => {
+        await redis.unsubscribe(INSTRUMENTS_CHANNEL);
+        redis.disconnect();
+        controller.close();
+      });
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+      'Content-Type': 'text/event-stream',
+    },
+  });
+}

--- a/apps/web/src/instrumentation.ts
+++ b/apps/web/src/instrumentation.ts
@@ -1,0 +1,13 @@
+/**
+ * Next.js instrumentation hook — runs once on server startup (Node.js runtime).
+ * Used to fetch the active instrument list from `instrument-registry` so the
+ * 24-hour ticker filter is ready before any requests arrive.
+ *
+ * https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation
+ */
+export async function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    const { initInstrumentRegistry } = await import('@/lib/instruments/registry');
+    await initInstrumentRegistry();
+  }
+}

--- a/apps/web/src/lib/instruments/registry.ts
+++ b/apps/web/src/lib/instruments/registry.ts
@@ -1,0 +1,95 @@
+/**
+ * Fetches the active instrument list from `instrument-registry` on startup
+ * and maintains an in-memory set of active symbols for ticker filtering.
+ *
+ * Gracefully degrades to allowing all tickers through if the service is
+ * unreachable.
+ */
+
+interface Instrument {
+  symbol: string;
+  pair: string;
+  contractType: string;
+  deliveryDate: number;
+  status: string;
+  lastSyncedAt: string;
+}
+
+let activeSymbols: Set<string> | null = null;
+let initialized = false;
+
+export async function initInstrumentRegistry(): Promise<void> {
+  if (initialized) return;
+  initialized = true;
+
+  const baseUrl = process.env.INSTRUMENT_REGISTRY_URL;
+  if (!baseUrl) {
+    console.warn(
+      '[instruments] INSTRUMENT_REGISTRY_URL is not set — ticker filter disabled, all tickers allowed through',
+    );
+    return;
+  }
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5_000);
+    let res: Response;
+    try {
+      res = await fetch(`${baseUrl}/instruments`, { signal: controller.signal });
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
+
+    const data = (await res.json()) as Instrument[];
+    activeSymbols = new Set(data.map((i) => i.symbol.toUpperCase()));
+    console.info(
+      `[instruments] Loaded ${activeSymbols.size} active instruments from instrument-registry`,
+    );
+  } catch (err) {
+    console.warn(
+      '[instruments] Failed to fetch instruments from instrument-registry — ticker filter disabled, all tickers allowed through:',
+      err,
+    );
+    activeSymbols = null;
+  }
+}
+
+/**
+ * Returns true if the given symbol is in the active instrument list.
+ * When the registry was unreachable on startup, all symbols are allowed through.
+ */
+export function isActiveInstrument(symbol: string): boolean {
+  if (activeSymbols === null) return true;
+  return activeSymbols.has(symbol.toUpperCase());
+}
+
+/**
+ * Returns a snapshot of the active symbols set, or null if unavailable.
+ */
+export function getActiveSymbols(): Set<string> | null {
+  return activeSymbols;
+}
+
+/**
+ * Updates the active symbol list with the result of an instrument change event.
+ * Called by the instruments stream handler when Redis publishes changes.
+ */
+export function applyInstrumentChanges(changes: {
+  newListings: string[];
+  delistings: string[];
+}): void {
+  if (activeSymbols === null) {
+    // Registry was unreachable at startup; initialise from the change event
+    activeSymbols = new Set();
+  }
+  for (const symbol of changes.newListings) {
+    activeSymbols.add(symbol.toUpperCase());
+  }
+  for (const symbol of changes.delistings) {
+    activeSymbols.delete(symbol.toUpperCase());
+  }
+}

--- a/apps/web/src/lib/redis.ts
+++ b/apps/web/src/lib/redis.ts
@@ -1,0 +1,18 @@
+/**
+ * Creates a dedicated ioredis subscriber client for use in SSE route handlers.
+ *
+ * Each SSE connection gets its own subscriber so that unsubscribing on
+ * disconnect does not affect other open connections.
+ */
+import Redis from 'ioredis';
+
+export function createRedisSubscriber(): Redis {
+  return new Redis({
+    host: process.env.REDIS_HOST ?? 'localhost',
+    port: parseInt(process.env.REDIS_PORT ?? '6379', 10),
+    lazyConnect: true,
+  });
+}
+
+export const INSTRUMENTS_CHANNEL =
+  process.env.REDIS_INSTRUMENTS_CHANNEL ?? 'exchange:instruments';


### PR DESCRIPTION
Implements #issue-30: integrates the Next.js app with the `instrument-registry` service.

- Fetches the active instrument list on server startup via `src/instrumentation.ts`
- Maintains an in-memory symbol set for ticker filtering (`isActiveInstrument`)
- Graceful degradation if `instrument-registry` is unreachable
- New `GET /api/instruments/stream` SSE endpoint subscribes to Redis `exchange:instruments` and forwards events to the browser
- Adds `ioredis` dependency and env var documentation

Closes #30

Generated with [Claude Code](https://claude.ai/code)