### PR TITLE
Add probability-materializer CLI app

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -50,4 +50,8 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           claude_args: |
-            --allowed-tools "Bash(gh pr:*) --allowed-tools Bash(git fetch:*) --allowed-tools Bash(git checkout:*) --allowed-tools Bash(git branch:*)"
+            --model claude-sonnet-4-6
+            --allowed-tools "Bash(gh pr:*)"
+            --allowed-tools "Bash(git branch:*)"
+            --allowed-tools "Bash(git checkout:*)"
+            --allowed-tools "Bash(git fetch:*)"

--- a/apps/probability-materializer/.env.example
+++ b/apps/probability-materializer/.env.example
@@ -1,0 +1,14 @@
+# PostgreSQL connection string — required
+# Format: postgres://user:password@host:port/database
+DATABASE_URL=postgres://changeme:changeme@localhost:5432/changeme
+
+# Instrument to compute — required
+# Example: BTCUSDT
+INSTRUMENT=BTCUSDT
+
+# Timeframe to compute — optional, defaults to 5m
+TIMEFRAME=5m
+
+# Pino log level — optional, defaults to info
+# Options: trace, debug, info, warn, error, fatal
+LOG_LEVEL=info

--- a/apps/probability-materializer/README.md
+++ b/apps/probability-materializer/README.md
@@ -1,0 +1,70 @@
+# Probability Materializer Service
+
+CLI tool that computes pattern probabilities from OHLCV candle data and stores the results in PostgreSQL. It analyzes 3-candle sequences to calculate the probability that the next (4th) candle will move up or down, enabling pattern-based trading signals.
+
+## How it works
+
+1. Reads `ohlcv_candles` from the database (populated by `candle-collector`)
+2. Classifies each candle into a directional label using `pct_change` and `body_ratio`
+3. Slides a 4-candle window across the series, grouping sequences by their 3-candle pattern
+4. Calculates `up_probability` and `down_probability` for each unique pattern
+5. Upserts results into the `pattern_probabilities` table
+
+### Candle classification
+
+Each candle is classified using `classifyCandle` from `@crypto-terminal/trade-formula`:
+
+| Label                                     | Direction                                                                              |
+| ----------------------------------------- | -------------------------------------------------------------------------------------- |
+| `up_strong`, `up_medium`, `up_weak`       | Bullish                                                                                |
+| `down_strong`, `down_medium`, `down_weak` | Bearish                                                                                |
+| `flat`                                    | Excluded — candles classified as `flat` cause the entire 4-candle window to be skipped |
+
+### Output schema (`pattern_probabilities`)
+
+| Column                               | Description                          |
+| ------------------------------------ | ------------------------------------ |
+| `instrument`                         | Symbol, e.g. `BTCUSDT`               |
+| `timeframe`                          | Candle interval, e.g. `5m`           |
+| `c1_label`, `c2_label`, `c3_label`   | The 3-candle pattern                 |
+| `occurrences`                        | How many times this pattern occurred |
+| `up_count`, `down_count`             | Outcome counts                       |
+| `up_probability`, `down_probability` | Outcome percentages (0–100)          |
+| `computed_at`                        | Timestamp of last computation        |
+
+Primary key: `(instrument, timeframe, c1_label, c2_label, c3_label)`. All writes are upserts — safe to re-run.
+
+## Environment variables
+
+| Variable       | Required | Default | Description                                                    |
+| -------------- | -------- | ------- | -------------------------------------------------------------- |
+| `DATABASE_URL` | Yes      | —       | PostgreSQL connection string                                   |
+| `INSTRUMENT`   | Yes      | —       | Symbol to compute, e.g. `BTCUSDT`                              |
+| `TIMEFRAME`    | No       | `5m`    | Candle timeframe                                               |
+| `LOG_LEVEL`    | No       | `info`  | Pino log level (`trace` / `debug` / `info` / `warn` / `error`) |
+
+Copy `.env.example` and fill in your values:
+
+```bash
+cp .env.example .env
+```
+
+## Usage
+
+```bash
+# Run the computation pipeline
+pnpm run compute
+
+# Database migrations
+pnpm run db:generate   # generate migrations after schema changes
+pnpm run db:migrate    # apply pending migrations
+
+# Type-check
+pnpm run typecheck
+```
+
+## Dependencies
+
+- **Input:** `ohlcv_candles` table — must be populated by `apps/candle-collector`
+- **Output:** `pattern_probabilities` table — consumed by downstream trading logic
+- **Runtime:** Node.js ≥ 20, PostgreSQL

--- a/apps/probability-materializer/drizzle.config.ts
+++ b/apps/probability-materializer/drizzle.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'drizzle-kit';
+
+export default defineConfig({
+  schema: './src/db/schema.ts',
+  out: './src/db/migrations',
+  dialect: 'postgresql',
+  dbCredentials: {
+    url: process.env.DATABASE_URL!,
+  },
+});

--- a/apps/probability-materializer/package.json
+++ b/apps/probability-materializer/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "probability-materializer",
+  "version": "0.1.0",
+  "private": true,
+  "description": "CLI that computes pattern probabilities from OHLCV candles and upserts them into the pattern_probabilities table",
+  "type": "module",
+  "scripts": {
+    "compute": "tsx --env-file .env src/index.ts",
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@crypto-terminal/trade-formula": "workspace:*",
+    "drizzle-orm": "^0.40.0",
+    "pg": "^8.13.3",
+    "pino": "^9.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/pg": "^8.11.0",
+    "drizzle-kit": "^0.30.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/apps/probability-materializer/src/compute.ts
+++ b/apps/probability-materializer/src/compute.ts
@@ -1,0 +1,103 @@
+import { classifyCandle } from '@crypto-terminal/trade-formula';
+
+interface OhlcvRow {
+  pct_change: number;
+  body_ratio: number;
+}
+
+interface PatternAccumulator {
+  up_count: number;
+  down_count: number;
+}
+
+export interface ComputedRow {
+  instrument: string;
+  timeframe: string;
+  c1_label: string;
+  c2_label: string;
+  c3_label: string;
+  occurrences: number;
+  up_count: number;
+  down_count: number;
+  up_probability: number;
+  down_probability: number;
+}
+
+export interface ComputeResult {
+  rows: ComputedRow[];
+  total_windows: number;
+  skipped_windows: number;
+}
+
+export function computeProbabilities(
+  candles: OhlcvRow[],
+  instrument: string,
+  timeframe: string,
+): ComputeResult {
+  const accumulator = new Map<string, PatternAccumulator>();
+  let total_windows = 0;
+  let skipped_windows = 0;
+
+  for (let i = 0; i <= candles.length - 4; i++) {
+    total_windows++;
+
+    const c1 = candles[i]!;
+    const c2 = candles[i + 1]!;
+    const c3 = candles[i + 2]!;
+    const c4 = candles[i + 3]!;
+
+    const c1_label = classifyCandle(c1.pct_change, c1.body_ratio);
+    const c2_label = classifyCandle(c2.pct_change, c2.body_ratio);
+    const c3_label = classifyCandle(c3.pct_change, c3.body_ratio);
+
+    if (c1_label === 'flat' || c2_label === 'flat' || c3_label === 'flat') {
+      skipped_windows++;
+      continue;
+    }
+
+    const c4_label = classifyCandle(c4.pct_change, c4.body_ratio);
+
+    if (c4_label === 'flat') {
+      skipped_windows++;
+      continue;
+    }
+
+    const key = `${c1_label}|${c2_label}|${c3_label}`;
+    const existing = accumulator.get(key) ?? { up_count: 0, down_count: 0 };
+
+    if (c4_label.startsWith('up_')) {
+      existing.up_count++;
+    } else {
+      existing.down_count++;
+    }
+
+    accumulator.set(key, existing);
+  }
+
+  const rows: ComputedRow[] = [];
+
+  for (const [key, counts] of accumulator.entries()) {
+    const parts = key.split('|');
+    const c1_label = parts[0]!;
+    const c2_label = parts[1]!;
+    const c3_label = parts[2]!;
+    const occurrences = counts.up_count + counts.down_count;
+    const up_probability = (counts.up_count / occurrences) * 100;
+    const down_probability = (counts.down_count / occurrences) * 100;
+
+    rows.push({
+      instrument,
+      timeframe,
+      c1_label,
+      c2_label,
+      c3_label,
+      occurrences,
+      up_count: counts.up_count,
+      down_count: counts.down_count,
+      up_probability,
+      down_probability,
+    });
+  }
+
+  return { rows, total_windows, skipped_windows };
+}

--- a/apps/probability-materializer/src/compute.ts
+++ b/apps/probability-materializer/src/compute.ts
@@ -67,8 +67,10 @@ export function computeProbabilities(
 
     if (c4_label.startsWith('up_')) {
       existing.up_count++;
-    } else {
+    } else if (c4_label.startsWith('down_')) {
       existing.down_count++;
+    } else {
+      throw new Error(`Unexpected c4_label: ${c4_label}`);
     }
 
     accumulator.set(key, existing);

--- a/apps/probability-materializer/src/config.ts
+++ b/apps/probability-materializer/src/config.ts
@@ -1,0 +1,17 @@
+const required = ['DATABASE_URL', 'INSTRUMENT'] as const;
+
+for (const key of required) {
+  if (!process.env[key]) {
+    console.error(`[config] Missing required environment variable: ${key}`);
+    process.exit(1);
+  }
+}
+
+export const config = {
+  database: {
+    url: process.env.DATABASE_URL as string,
+  },
+  instrument: process.env.INSTRUMENT as string,
+  timeframe: process.env.TIMEFRAME ?? '5m',
+  logLevel: process.env.LOG_LEVEL ?? 'info',
+};

--- a/apps/probability-materializer/src/db/client.ts
+++ b/apps/probability-materializer/src/db/client.ts
@@ -1,0 +1,9 @@
+import { drizzle } from 'drizzle-orm/node-postgres';
+import type pg from 'pg';
+import * as schema from './schema.js';
+
+export function createDb(pool: pg.Pool) {
+  return drizzle(pool, { schema });
+}
+
+export type Db = ReturnType<typeof createDb>;

--- a/apps/probability-materializer/src/db/migrations/0000_create_pattern_probabilities.sql
+++ b/apps/probability-materializer/src/db/migrations/0000_create_pattern_probabilities.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "pattern_probabilities" (
+	"instrument" varchar(100) NOT NULL,
+	"timeframe" varchar(10) NOT NULL,
+	"c1_label" varchar(20) NOT NULL,
+	"c2_label" varchar(20) NOT NULL,
+	"c3_label" varchar(20) NOT NULL,
+	"occurrences" integer NOT NULL,
+	"up_count" integer NOT NULL,
+	"down_count" integer NOT NULL,
+	"up_probability" double precision NOT NULL,
+	"down_probability" double precision NOT NULL,
+	"computed_at" timestamp NOT NULL,
+	CONSTRAINT "pattern_probabilities_instrument_timeframe_c1_label_c2_label_c3_label_pk" PRIMARY KEY("instrument","timeframe","c1_label","c2_label","c3_label")
+);

--- a/apps/probability-materializer/src/db/migrations/meta/_journal.json
+++ b/apps/probability-materializer/src/db/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1775001600000,
+      "tag": "0000_create_pattern_probabilities",
+      "breakpoints": true
+    }
+  ]
+}

--- a/apps/probability-materializer/src/db/ohlcv-read.ts
+++ b/apps/probability-materializer/src/db/ohlcv-read.ts
@@ -1,0 +1,16 @@
+import { bigint, doublePrecision, pgTable, primaryKey, varchar } from 'drizzle-orm/pg-core';
+
+// Read-only table reference for querying ohlcv_candles.
+// Source of truth: apps/candle-collector/src/db/schema.ts
+// Only the columns required by probability computation are included here.
+export const ohlcvCandles = pgTable(
+  'ohlcv_candles',
+  {
+    instrument: varchar('instrument', { length: 100 }).notNull(),
+    open_time: bigint('open_time', { mode: 'number' }).notNull(),
+    timeframe: varchar('timeframe', { length: 10 }).notNull(),
+    pct_change: doublePrecision('pct_change').notNull(),
+    body_ratio: doublePrecision('body_ratio').notNull(),
+  },
+  (table) => [primaryKey({ columns: [table.instrument, table.open_time, table.timeframe] })],
+);

--- a/apps/probability-materializer/src/db/schema.ts
+++ b/apps/probability-materializer/src/db/schema.ts
@@ -1,0 +1,32 @@
+import { doublePrecision, integer, pgTable, primaryKey, timestamp, varchar } from 'drizzle-orm/pg-core';
+
+export const patternProbabilities = pgTable(
+  'pattern_probabilities',
+  {
+    instrument: varchar('instrument', { length: 100 }).notNull(),
+    timeframe: varchar('timeframe', { length: 10 }).notNull(),
+    c1_label: varchar('c1_label', { length: 20 }).notNull(),
+    c2_label: varchar('c2_label', { length: 20 }).notNull(),
+    c3_label: varchar('c3_label', { length: 20 }).notNull(),
+    occurrences: integer('occurrences').notNull(),
+    up_count: integer('up_count').notNull(),
+    down_count: integer('down_count').notNull(),
+    up_probability: doublePrecision('up_probability').notNull(),
+    down_probability: doublePrecision('down_probability').notNull(),
+    computed_at: timestamp('computed_at').notNull(),
+  },
+  (table) => [
+    primaryKey({
+      columns: [
+        table.instrument,
+        table.timeframe,
+        table.c1_label,
+        table.c2_label,
+        table.c3_label,
+      ],
+    }),
+  ],
+);
+
+export type PatternProbability = typeof patternProbabilities.$inferSelect;
+export type NewPatternProbability = typeof patternProbabilities.$inferInsert;

--- a/apps/probability-materializer/src/index.ts
+++ b/apps/probability-materializer/src/index.ts
@@ -1,0 +1,79 @@
+import pg from 'pg';
+import pino from 'pino';
+import { and, asc, eq } from 'drizzle-orm';
+import { config } from './config.js';
+import { createDb } from './db/client.js';
+import { ohlcvCandles } from './db/ohlcv-read.js';
+import { computeProbabilities } from './compute.js';
+import { upsertProbabilities } from './upsert.js';
+
+const log = pino({ level: config.logLevel });
+const { Pool } = pg;
+
+async function main() {
+  const pool = new Pool({ connectionString: config.database.url });
+
+  try {
+    const client = await pool.connect();
+    await client.query('SELECT 1');
+    client.release();
+    log.info('[db] Database connection established');
+  } catch (err) {
+    log.error({ err }, '[db] Failed to connect to database');
+    process.exit(1);
+  }
+
+  const db = createDb(pool);
+
+  log.info(
+    { instrument: config.instrument, timeframe: config.timeframe },
+    '[pipeline] Fetching candles',
+  );
+
+  const candles = await db
+    .select({
+      pct_change: ohlcvCandles.pct_change,
+      body_ratio: ohlcvCandles.body_ratio,
+    })
+    .from(ohlcvCandles)
+    .where(
+      and(
+        eq(ohlcvCandles.instrument, config.instrument),
+        eq(ohlcvCandles.timeframe, config.timeframe),
+      ),
+    )
+    .orderBy(asc(ohlcvCandles.open_time));
+
+  log.info({ count: candles.length }, '[pipeline] Candles fetched');
+
+  const { rows, total_windows, skipped_windows } = computeProbabilities(
+    candles,
+    config.instrument,
+    config.timeframe,
+  );
+
+  log.info(
+    { total_windows, skipped_windows, computed_rows: rows.length },
+    '[pipeline] Computation complete',
+  );
+
+  const upserted = await upsertProbabilities(db, rows);
+
+  log.info(
+    {
+      instrument: config.instrument,
+      timeframe: config.timeframe,
+      total_windows,
+      skipped_windows,
+      rows_upserted: upserted,
+    },
+    '[pipeline] Done',
+  );
+
+  await pool.end();
+}
+
+main().catch((err) => {
+  log.error({ err }, '[pipeline] Unrecoverable error');
+  process.exit(1);
+});

--- a/apps/probability-materializer/src/index.ts
+++ b/apps/probability-materializer/src/index.ts
@@ -14,63 +14,65 @@ async function main() {
   const pool = new Pool({ connectionString: config.database.url });
 
   try {
-    const client = await pool.connect();
-    await client.query('SELECT 1');
-    client.release();
-    log.info('[db] Database connection established');
-  } catch (err) {
-    log.error({ err }, '[db] Failed to connect to database');
-    process.exit(1);
+    try {
+      const client = await pool.connect();
+      await client.query('SELECT 1');
+      client.release();
+      log.info('[db] Database connection established');
+    } catch (err) {
+      log.error({ err }, '[db] Failed to connect to database');
+      process.exit(1);
+    }
+
+    const db = createDb(pool);
+
+    log.info(
+      { instrument: config.instrument, timeframe: config.timeframe },
+      '[pipeline] Fetching candles',
+    );
+
+    const candles = await db
+      .select({
+        pct_change: ohlcvCandles.pct_change,
+        body_ratio: ohlcvCandles.body_ratio,
+      })
+      .from(ohlcvCandles)
+      .where(
+        and(
+          eq(ohlcvCandles.instrument, config.instrument),
+          eq(ohlcvCandles.timeframe, config.timeframe),
+        ),
+      )
+      .orderBy(asc(ohlcvCandles.open_time));
+
+    log.info({ count: candles.length }, '[pipeline] Candles fetched');
+
+    const { rows, total_windows, skipped_windows } = computeProbabilities(
+      candles,
+      config.instrument,
+      config.timeframe,
+    );
+
+    log.info(
+      { total_windows, skipped_windows, computed_rows: rows.length },
+      '[pipeline] Computation complete',
+    );
+
+    const upserted = await upsertProbabilities(db, rows);
+
+    log.info(
+      {
+        instrument: config.instrument,
+        timeframe: config.timeframe,
+        total_windows,
+        skipped_windows,
+        rows_upserted: upserted,
+      },
+      '[pipeline] Done',
+    );
+  } finally {
+    await pool.end();
   }
-
-  const db = createDb(pool);
-
-  log.info(
-    { instrument: config.instrument, timeframe: config.timeframe },
-    '[pipeline] Fetching candles',
-  );
-
-  const candles = await db
-    .select({
-      pct_change: ohlcvCandles.pct_change,
-      body_ratio: ohlcvCandles.body_ratio,
-    })
-    .from(ohlcvCandles)
-    .where(
-      and(
-        eq(ohlcvCandles.instrument, config.instrument),
-        eq(ohlcvCandles.timeframe, config.timeframe),
-      ),
-    )
-    .orderBy(asc(ohlcvCandles.open_time));
-
-  log.info({ count: candles.length }, '[pipeline] Candles fetched');
-
-  const { rows, total_windows, skipped_windows } = computeProbabilities(
-    candles,
-    config.instrument,
-    config.timeframe,
-  );
-
-  log.info(
-    { total_windows, skipped_windows, computed_rows: rows.length },
-    '[pipeline] Computation complete',
-  );
-
-  const upserted = await upsertProbabilities(db, rows);
-
-  log.info(
-    {
-      instrument: config.instrument,
-      timeframe: config.timeframe,
-      total_windows,
-      skipped_windows,
-      rows_upserted: upserted,
-    },
-    '[pipeline] Done',
-  );
-
-  await pool.end();
 }
 
 main().catch((err) => {

--- a/apps/probability-materializer/src/upsert.ts
+++ b/apps/probability-materializer/src/upsert.ts
@@ -1,0 +1,34 @@
+import { sql } from 'drizzle-orm';
+import type { Db } from './db/client.js';
+import { patternProbabilities } from './db/schema.js';
+import type { ComputedRow } from './compute.js';
+
+export async function upsertProbabilities(db: Db, rows: ComputedRow[]): Promise<number> {
+  if (rows.length === 0) return 0;
+
+  const now = new Date();
+  const values = rows.map((row) => ({ ...row, computed_at: now }));
+
+  await db
+    .insert(patternProbabilities)
+    .values(values)
+    .onConflictDoUpdate({
+      target: [
+        patternProbabilities.instrument,
+        patternProbabilities.timeframe,
+        patternProbabilities.c1_label,
+        patternProbabilities.c2_label,
+        patternProbabilities.c3_label,
+      ],
+      set: {
+        occurrences: sql`excluded.occurrences`,
+        up_count: sql`excluded.up_count`,
+        down_count: sql`excluded.down_count`,
+        up_probability: sql`excluded.up_probability`,
+        down_probability: sql`excluded.down_probability`,
+        computed_at: sql`excluded.computed_at`,
+      },
+    });
+
+  return rows.length;
+}

--- a/apps/probability-materializer/tsconfig.json
+++ b/apps/probability-materializer/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "pg:down": "podman compose -f apps/postgres/compose.yaml down",
     "pg:stop": "podman compose -f apps/postgres/compose.yaml stop",
     "pg:logs": "podman compose -f apps/postgres/compose.yaml logs -f postgres",
-    "pg:destroy": "bash apps/postgres/destroy-data.sh"
+    "pg:destroy": "bash apps/postgres/destroy-data.sh",
+    "compute:probability-materializer": "pnpm --filter probability-materializer compute"
   },
   "engines": {
     "node": ">=20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,37 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
+  apps/probability-materializer:
+    dependencies:
+      '@crypto-terminal/trade-formula':
+        specifier: workspace:*
+        version: link:../../packages/trade-formula
+      drizzle-orm:
+        specifier: ^0.40.0
+        version: 0.40.1(@types/pg@8.20.0)(gel@2.2.0)(pg@8.20.0)
+      pg:
+        specifier: ^8.13.3
+        version: 8.20.0
+      pino:
+        specifier: ^9.0.0
+        version: 9.14.0
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
+      '@types/pg':
+        specifier: ^8.11.0
+        version: 8.20.0
+      drizzle-kit:
+        specifier: ^0.30.0
+        version: 0.30.6
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   apps/web:
     dependencies:
       '@tanstack/react-query':
@@ -1743,6 +1774,9 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pino-abstract-transport@2.0.0:
+    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+
   pino-abstract-transport@3.0.0:
     resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
 
@@ -1751,6 +1785,10 @@ packages:
 
   pino@10.3.1:
     resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
+
+  pino@9.14.0:
+    resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
     hasBin: true
 
   pirates@4.0.7:
@@ -1974,6 +2012,9 @@ packages:
 
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  thread-stream@3.1.0:
+    resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
 
   thread-stream@4.0.0:
     resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
@@ -3297,6 +3338,10 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  pino-abstract-transport@2.0.0:
+    dependencies:
+      split2: 4.2.0
+
   pino-abstract-transport@3.0.0:
     dependencies:
       split2: 4.2.0
@@ -3316,6 +3361,20 @@ snapshots:
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.1
       thread-stream: 4.0.0
+
+  pino@9.14.0:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 3.1.0
 
   pirates@4.0.7: {}
 
@@ -3532,6 +3591,10 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  thread-stream@3.1.0:
+    dependencies:
+      real-require: 0.2.0
 
   thread-stream@4.0.0:
     dependencies:


### PR DESCRIPTION
Implements a TypeScript CLI that reads `ohlcv_candles` from Postgres, slides a 4-candle window, classifies c1–c3 with `classifyCandle()` from `@crypto-terminal/trade-formula`, and upserts computed up/down probabilities into the new `pattern_probabilities` table.

Closes #45

Generated with [Claude Code](https://claude.ai/code)