### PR TITLE
Scaffold core backtest infrastructure for trading simulator

### DIFF
--- a/apps/trading-simulator/.env.example
+++ b/apps/trading-simulator/.env.example
@@ -1,0 +1,12 @@
+# Required: PostgreSQL connection string for the crypto_terminal database
+DATABASE_URL=postgres://user:password@localhost:5432/crypto_terminal
+
+# Optional: instrument and timeframe to backtest (defaults shown)
+INSTRUMENT=BTCUSDT
+TIMEFRAME=5m
+
+# Optional: starting portfolio balance in USD (default: 1000, must be > 0)
+INITIAL_BALANCE=1000
+
+# Optional: pino log level — trace | debug | info | warn | error (default: info)
+LOG_LEVEL=info

--- a/apps/trading-simulator/README.md
+++ b/apps/trading-simulator/README.md
@@ -1,0 +1,68 @@
+# trading-simulator
+
+Backtesting engine for OHLCV-based trading strategies. Iterates through historical BTCUSDT 5-minute candles, runs a strategy against a sliding 3-candle window, and tracks portfolio performance (balance, SL/TP hits, P&L).
+
+## Setup
+
+1. Copy `.env.example` to `.env` and set the required variables:
+
+```env
+DATABASE_URL=postgres://user:password@localhost:5432/crypto_terminal
+INSTRUMENT=BTCUSDT
+TIMEFRAME=5m
+INITIAL_BALANCE=1000
+LOG_LEVEL=info
+```
+
+2. Install dependencies from the monorepo root:
+
+```bash
+pnpm install
+```
+
+## Usage
+
+Run a backtest with the default dummy strategy:
+
+```bash
+pnpm start
+```
+
+Pass a strategy name and optional initial balance via environment variables or CLI args:
+
+```bash
+INSTRUMENT=BTCUSDT INITIAL_BALANCE=5000 pnpm start -- --strategy dummy
+```
+
+## Architecture
+
+```
+src/
+├── config.ts               — Environment configuration
+├── index.ts                — CLI entry point
+├── db/
+│   ├── client.ts           — Drizzle + pg.Pool setup
+│   ├── schema.ts           — Read-only Drizzle schema (ohlcv_candles, pattern_probabilities)
+│   └── queries.ts          — Data fetchers
+└── engine/
+    ├── types.ts            — Shared TypeScript interfaces
+    ├── time-machine.ts     — Sliding 3-candle window iterator
+    ├── portfolio.ts        — Balance and position tracker
+    └── backtest-runner.ts  — Main orchestration loop
+```
+
+## Key Concepts
+
+- **TimeMachine**: iterates candles in a sliding `[c1, c2, c3]` window, one step at a time
+- **Portfolio**: holds at most one open position; checks SL/TP on every candle; computes P&L
+- **BacktestRunner**: ties TimeMachine + Portfolio + strategy together in a single loop
+- **StrategyRunner**: interface all strategies must implement — receives `[c1, c2, c3]` and returns a `TradeSignal` or `null`
+
+## Database
+
+Reads from the shared `crypto_terminal` PostgreSQL database:
+
+| Table | Purpose |
+|-------|---------|
+| `public.ohlcv_candles` | Source OHLCV data (written by candle-collector) |
+| `public.pattern_probabilities` | Precomputed pattern stats (written by probability-materializer) |

--- a/apps/trading-simulator/package.json
+++ b/apps/trading-simulator/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "trading-simulator",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Backtesting engine for OHLCV-based trading strategies",
+  "type": "module",
+  "scripts": {
+    "start": "tsx --env-file .env src/index.ts",
+    "dev": "tsx --env-file .env --watch src/index.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@crypto-terminal/trade-formula": "workspace:*",
+    "drizzle-orm": "^0.40.0",
+    "pg": "^8.13.3",
+    "pino": "^9.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/pg": "^8.11.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/apps/trading-simulator/src/config.ts
+++ b/apps/trading-simulator/src/config.ts
@@ -13,6 +13,13 @@ export const config = {
   },
   instrument: process.env.INSTRUMENT ?? 'BTCUSDT',
   timeframe: process.env.TIMEFRAME ?? '5m',
-  initialBalance: Number(process.env.INITIAL_BALANCE ?? '1000'),
+  initialBalance: (() => {
+    const v = Number(process.env.INITIAL_BALANCE ?? '1000');
+    if (isNaN(v) || v <= 0) {
+      console.error('[config] INITIAL_BALANCE must be a positive number');
+      process.exit(1);
+    }
+    return v;
+  })(),
   logLevel: process.env.LOG_LEVEL ?? 'info',
 };

--- a/apps/trading-simulator/src/config.ts
+++ b/apps/trading-simulator/src/config.ts
@@ -1,0 +1,18 @@
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`[config] Missing required environment variable: ${name}`);
+    process.exit(1);
+  }
+  return value;
+}
+
+export const config = {
+  database: {
+    url: requireEnv('DATABASE_URL'),
+  },
+  instrument: process.env.INSTRUMENT ?? 'BTCUSDT',
+  timeframe: process.env.TIMEFRAME ?? '5m',
+  initialBalance: Number(process.env.INITIAL_BALANCE ?? '1000'),
+  logLevel: process.env.LOG_LEVEL ?? 'info',
+};

--- a/apps/trading-simulator/src/db/client.ts
+++ b/apps/trading-simulator/src/db/client.ts
@@ -1,0 +1,9 @@
+import { drizzle } from 'drizzle-orm/node-postgres';
+import type pg from 'pg';
+import * as schema from './schema.js';
+
+export function createDb(pool: pg.Pool) {
+  return drizzle(pool, { schema });
+}
+
+export type Db = ReturnType<typeof createDb>;

--- a/apps/trading-simulator/src/db/queries.ts
+++ b/apps/trading-simulator/src/db/queries.ts
@@ -14,6 +14,8 @@ export async function fetchAllCandles(
   instrument: string,
   timeframe: string,
 ): Promise<OhlcCandle[]> {
+  // NOTE: full in-memory load — for large datasets this can be significant.
+  // Consider streaming or pagination if memory becomes a concern.
   const rows = await db
     .select({
       open_time: ohlcvCandles.open_time,

--- a/apps/trading-simulator/src/db/queries.ts
+++ b/apps/trading-simulator/src/db/queries.ts
@@ -43,6 +43,9 @@ export async function fetchAllCandles(
 /**
  * Look up pattern probability stats for a specific 3-candle sequence.
  * Returns null if no matching row exists (pattern not yet materialised).
+ *
+ * Used by strategies that incorporate historical pattern probabilities into
+ * their signal logic (e.g. pattern-probability strategy).
  */
 export async function fetchPatternProbability(
   db: Db,

--- a/apps/trading-simulator/src/db/queries.ts
+++ b/apps/trading-simulator/src/db/queries.ts
@@ -1,0 +1,70 @@
+import { and, asc, eq } from 'drizzle-orm';
+import type { Db } from './client.js';
+import { ohlcvCandles, patternProbabilities, type PatternProbability } from './schema.js';
+import type { OhlcCandle } from '../engine/types.js';
+import type { CandleLabel } from '@crypto-terminal/trade-formula';
+
+/**
+ * Fetch all OHLCV candles for the given instrument and timeframe,
+ * ordered chronologically. Returns the full set as an in-memory array
+ * ready for TimeMachine iteration.
+ */
+export async function fetchAllCandles(
+  db: Db,
+  instrument: string,
+  timeframe: string,
+): Promise<OhlcCandle[]> {
+  const rows = await db
+    .select({
+      open_time: ohlcvCandles.open_time,
+      open: ohlcvCandles.open,
+      high: ohlcvCandles.high,
+      low: ohlcvCandles.low,
+      close: ohlcvCandles.close,
+      volume: ohlcvCandles.volume,
+      quote_volume: ohlcvCandles.quote_volume,
+      num_trades: ohlcvCandles.num_trades,
+      pct_change: ohlcvCandles.pct_change,
+      candle_range: ohlcvCandles.candle_range,
+      body_ratio: ohlcvCandles.body_ratio,
+    })
+    .from(ohlcvCandles)
+    .where(
+      and(
+        eq(ohlcvCandles.instrument, instrument),
+        eq(ohlcvCandles.timeframe, timeframe),
+      ),
+    )
+    .orderBy(asc(ohlcvCandles.open_time));
+
+  return rows;
+}
+
+/**
+ * Look up pattern probability stats for a specific 3-candle sequence.
+ * Returns null if no matching row exists (pattern not yet materialised).
+ */
+export async function fetchPatternProbability(
+  db: Db,
+  instrument: string,
+  timeframe: string,
+  c1Label: CandleLabel,
+  c2Label: CandleLabel,
+  c3Label: CandleLabel,
+): Promise<PatternProbability | null> {
+  const rows = await db
+    .select()
+    .from(patternProbabilities)
+    .where(
+      and(
+        eq(patternProbabilities.instrument, instrument),
+        eq(patternProbabilities.timeframe, timeframe),
+        eq(patternProbabilities.c1_label, c1Label),
+        eq(patternProbabilities.c2_label, c2Label),
+        eq(patternProbabilities.c3_label, c3Label),
+      ),
+    )
+    .limit(1);
+
+  return rows[0] ?? null;
+}

--- a/apps/trading-simulator/src/db/schema.ts
+++ b/apps/trading-simulator/src/db/schema.ts
@@ -1,0 +1,72 @@
+/**
+ * Read-only Drizzle schema referencing tables owned by other apps.
+ *
+ * Source of truth:
+ *   ohlcv_candles       → apps/candle-collector/src/db/schema.ts
+ *   pattern_probabilities → apps/probability-materializer/src/db/schema.ts
+ */
+
+import {
+  bigint,
+  doublePrecision,
+  integer,
+  pgTable,
+  primaryKey,
+  timestamp,
+  varchar,
+} from 'drizzle-orm/pg-core';
+
+// ── ohlcv_candles ─────────────────────────────────────────────────────────────
+
+export const ohlcvCandles = pgTable(
+  'ohlcv_candles',
+  {
+    instrument: varchar('instrument', { length: 100 }).notNull(),
+    open_time: bigint('open_time', { mode: 'number' }).notNull(),
+    timeframe: varchar('timeframe', { length: 10 }).notNull(),
+    open: doublePrecision('open').notNull(),
+    high: doublePrecision('high').notNull(),
+    low: doublePrecision('low').notNull(),
+    close: doublePrecision('close').notNull(),
+    volume: doublePrecision('volume').notNull(),
+    quote_volume: doublePrecision('quote_volume').notNull(),
+    num_trades: bigint('num_trades', { mode: 'number' }).notNull(),
+    // Derived fields — computed at ingestion time by candle-collector
+    pct_change: doublePrecision('pct_change').notNull(),
+    candle_range: doublePrecision('candle_range').notNull(),
+    body_ratio: doublePrecision('body_ratio').notNull(),
+  },
+  (table) => [primaryKey({ columns: [table.instrument, table.open_time, table.timeframe] })],
+);
+
+// ── pattern_probabilities ─────────────────────────────────────────────────────
+
+export const patternProbabilities = pgTable(
+  'pattern_probabilities',
+  {
+    instrument: varchar('instrument', { length: 100 }).notNull(),
+    timeframe: varchar('timeframe', { length: 10 }).notNull(),
+    c1_label: varchar('c1_label', { length: 20 }).notNull(),
+    c2_label: varchar('c2_label', { length: 20 }).notNull(),
+    c3_label: varchar('c3_label', { length: 20 }).notNull(),
+    occurrences: integer('occurrences').notNull(),
+    up_count: integer('up_count').notNull(),
+    down_count: integer('down_count').notNull(),
+    up_probability: doublePrecision('up_probability').notNull(),
+    down_probability: doublePrecision('down_probability').notNull(),
+    computed_at: timestamp('computed_at').notNull(),
+  },
+  (table) => [
+    primaryKey({
+      columns: [
+        table.instrument,
+        table.timeframe,
+        table.c1_label,
+        table.c2_label,
+        table.c3_label,
+      ],
+    }),
+  ],
+);
+
+export type PatternProbability = typeof patternProbabilities.$inferSelect;

--- a/apps/trading-simulator/src/engine/backtest-runner.ts
+++ b/apps/trading-simulator/src/engine/backtest-runner.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events';
-import type { OhlcCandle, BacktestResults, ExecutedTrade, StrategyRunner } from './types.js';
+import type { OhlcCandle, BacktestResults, ExecutedTrade, StrategyRunner, TradeSignal } from './types.js';
 import { TimeMachine } from './time-machine.js';
 import { Portfolio } from './portfolio.js';
 
@@ -7,7 +7,7 @@ import { Portfolio } from './portfolio.js';
 
 export interface BacktestEvents {
   candle: [candles: [OhlcCandle, OhlcCandle, OhlcCandle], progress: string];
-  tradeOpened: [candle: OhlcCandle, signal: ReturnType<StrategyRunner['analyze']>];
+  tradeOpened: [candle: OhlcCandle, signal: TradeSignal];
   tradeClosed: [trade: ExecutedTrade];
   done: [results: BacktestResults];
 }
@@ -27,7 +27,7 @@ export interface BacktestRunnerOptions {
  * ```ts
  * const runner = new BacktestRunner({ candles, strategy, initialBalance: 1000 });
  * runner.on('tradeClosed', (trade) => console.log(trade));
- * const results = await runner.run();
+ * const results = runner.run();
  * ```
  */
 export class BacktestRunner extends EventEmitter {
@@ -44,7 +44,7 @@ export class BacktestRunner extends EventEmitter {
     this.progressInterval = options.progressInterval ?? 1000;
   }
 
-  async run(): Promise<BacktestResults> {
+  run(): BacktestResults {
     const timeMachine = new TimeMachine(this.candles);
     const portfolio = new Portfolio(this.initialBalance);
 
@@ -61,15 +61,8 @@ export class BacktestRunner extends EventEmitter {
         // SL is checked first — if both SL and TP levels are within the same candle,
         // SL takes priority (conservative assumption).
         const slHit = portfolio.checkStopLoss(c3);
-        if (!slHit) {
-          const tpHit = portfolio.checkTakeProfit(c3);
-          if (tpHit) {
-            const trades = portfolio.getTrades();
-            const closedTrade = trades[trades.length - 1]!;
-            this.emit('tradeClosed', closedTrade);
-            this.strategy.onTradeExecuted(closedTrade);
-          }
-        } else {
+        const tpHit = !slHit && portfolio.checkTakeProfit(c3);
+        if (slHit || tpHit) {
           const trades = portfolio.getTrades();
           const closedTrade = trades[trades.length - 1]!;
           this.emit('tradeClosed', closedTrade);
@@ -80,22 +73,25 @@ export class BacktestRunner extends EventEmitter {
       if (!portfolio.hasOpenPosition()) {
         const signal = this.strategy.analyze(window);
         if (signal !== null) {
-          portfolio.openPosition(signal);
+          portfolio.openPosition(signal, c3.open_time);
           this.emit('tradeOpened', c3, signal);
         }
       }
 
-      if (windowCount % this.progressInterval === 0) {
+      if (windowCount % this.progressInterval === 0 && process.stdout.isTTY) {
         process.stdout.write(`\r[backtest] ${timeMachine.progress()}`);
       }
     }
 
     // Clear the progress line
-    process.stdout.write('\n');
+    if (process.stdout.isTTY) {
+      process.stdout.write('\n');
+    }
 
     const trades = portfolio.getTrades();
     const winCount = trades.filter((t) => t.pnlDollar > 0).length;
-    const lossCount = trades.filter((t) => t.pnlDollar <= 0).length;
+    const lossCount = trades.filter((t) => t.pnlDollar < 0).length;
+    const breakEvenCount = trades.filter((t) => t.pnlDollar === 0).length;
     const totalPnlDollar = trades.reduce((sum, t) => sum + t.pnlDollar, 0);
 
     const results: BacktestResults = {
@@ -104,6 +100,7 @@ export class BacktestRunner extends EventEmitter {
       totalTrades: trades.length,
       winCount,
       lossCount,
+      breakEvenCount,
       winRate: trades.length > 0 ? (winCount / trades.length) * 100 : 0,
       totalPnlDollar,
       trades,

--- a/apps/trading-simulator/src/engine/backtest-runner.ts
+++ b/apps/trading-simulator/src/engine/backtest-runner.ts
@@ -1,0 +1,115 @@
+import { EventEmitter } from 'node:events';
+import type { OhlcCandle, BacktestResults, ExecutedTrade, StrategyRunner } from './types.js';
+import { TimeMachine } from './time-machine.js';
+import { Portfolio } from './portfolio.js';
+
+// ── Event map ─────────────────────────────────────────────────────────────────
+
+export interface BacktestEvents {
+  candle: [candles: [OhlcCandle, OhlcCandle, OhlcCandle], progress: string];
+  tradeOpened: [candle: OhlcCandle, signal: ReturnType<StrategyRunner['analyze']>];
+  tradeClosed: [trade: ExecutedTrade];
+  done: [results: BacktestResults];
+}
+
+export interface BacktestRunnerOptions {
+  candles: OhlcCandle[];
+  strategy: StrategyRunner;
+  initialBalance: number;
+  /** Log progress every N candles. Default 1000. */
+  progressInterval?: number;
+}
+
+/**
+ * Main backtest orchestration engine.
+ *
+ * Usage:
+ * ```ts
+ * const runner = new BacktestRunner({ candles, strategy, initialBalance: 1000 });
+ * runner.on('tradeClosed', (trade) => console.log(trade));
+ * const results = await runner.run();
+ * ```
+ */
+export class BacktestRunner extends EventEmitter {
+  private readonly candles: OhlcCandle[];
+  private readonly strategy: StrategyRunner;
+  private readonly initialBalance: number;
+  private readonly progressInterval: number;
+
+  constructor(options: BacktestRunnerOptions) {
+    super();
+    this.candles = options.candles;
+    this.strategy = options.strategy;
+    this.initialBalance = options.initialBalance;
+    this.progressInterval = options.progressInterval ?? 1000;
+  }
+
+  async run(): Promise<BacktestResults> {
+    const timeMachine = new TimeMachine(this.candles);
+    const portfolio = new Portfolio(this.initialBalance);
+
+    let windowCount = 0;
+    let window: [OhlcCandle, OhlcCandle, OhlcCandle] | null;
+
+    while ((window = timeMachine.next()) !== null) {
+      windowCount++;
+      const [, , c3] = window;
+
+      this.emit('candle', window, timeMachine.progress());
+
+      if (portfolio.hasOpenPosition()) {
+        // SL is checked first — if both SL and TP levels are within the same candle,
+        // SL takes priority (conservative assumption).
+        const slHit = portfolio.checkStopLoss(c3);
+        if (!slHit) {
+          const tpHit = portfolio.checkTakeProfit(c3);
+          if (tpHit) {
+            const trades = portfolio.getTrades();
+            const closedTrade = trades[trades.length - 1]!;
+            this.emit('tradeClosed', closedTrade);
+            this.strategy.onTradeExecuted(closedTrade);
+          }
+        } else {
+          const trades = portfolio.getTrades();
+          const closedTrade = trades[trades.length - 1]!;
+          this.emit('tradeClosed', closedTrade);
+          this.strategy.onTradeExecuted(closedTrade);
+        }
+      }
+
+      if (!portfolio.hasOpenPosition()) {
+        const signal = this.strategy.analyze(window);
+        if (signal !== null) {
+          portfolio.openPosition(signal);
+          this.emit('tradeOpened', c3, signal);
+        }
+      }
+
+      if (windowCount % this.progressInterval === 0) {
+        process.stdout.write(`\r[backtest] ${timeMachine.progress()}`);
+      }
+    }
+
+    // Clear the progress line
+    process.stdout.write('\n');
+
+    const trades = portfolio.getTrades();
+    const winCount = trades.filter((t) => t.pnlDollar > 0).length;
+    const lossCount = trades.filter((t) => t.pnlDollar <= 0).length;
+    const totalPnlDollar = trades.reduce((sum, t) => sum + t.pnlDollar, 0);
+
+    const results: BacktestResults = {
+      initialBalance: this.initialBalance,
+      finalBalance: portfolio.getBalance(),
+      totalTrades: trades.length,
+      winCount,
+      lossCount,
+      winRate: trades.length > 0 ? (winCount / trades.length) * 100 : 0,
+      totalPnlDollar,
+      trades,
+    };
+
+    this.emit('done', results);
+    return results;
+  }
+}

--- a/apps/trading-simulator/src/engine/backtest-runner.ts
+++ b/apps/trading-simulator/src/engine/backtest-runner.ts
@@ -119,6 +119,9 @@ export class BacktestRunner extends EventEmitter {
     };
 
     this.emit('done', results);
+    // NOTE: listeners are not removed after 'done'. For long-lived processes
+    // running multiple sequential backtests on the same instance, call
+    // runner.removeAllListeners() between runs to prevent listener accumulation.
     return results;
   }
 }

--- a/apps/trading-simulator/src/engine/backtest-runner.ts
+++ b/apps/trading-simulator/src/engine/backtest-runner.ts
@@ -88,6 +88,16 @@ export class BacktestRunner extends EventEmitter {
       process.stdout.write('\n');
     }
 
+    // Warn if a position is still open at the end of the dataset — it is never
+    // closed, so its unrealized P&L is silently excluded from finalBalance and
+    // trades[]. Callers comparing finalBalance - initialBalance vs totalPnlDollar
+    // will see them agree, but the open position's value is not reflected.
+    if (portfolio.hasOpenPosition()) {
+      process.stderr.write(
+        '[backtest] WARNING: backtest ended with an open position — unrealized P&L excluded from results\n',
+      );
+    }
+
     const trades = portfolio.getTrades();
     const winCount = trades.filter((t) => t.pnlDollar > 0).length;
     const lossCount = trades.filter((t) => t.pnlDollar < 0).length;

--- a/apps/trading-simulator/src/engine/backtest-runner.ts
+++ b/apps/trading-simulator/src/engine/backtest-runner.ts
@@ -111,6 +111,8 @@ export class BacktestRunner extends EventEmitter {
       winCount,
       lossCount,
       breakEvenCount,
+      // winRate denominator is ALL trades (wins + losses + breakevens), so a
+      // 50W/50L/10B record yields 50/110 = 45.5%, not 50/100 = 50%.
       winRate: trades.length > 0 ? (winCount / trades.length) * 100 : 0,
       totalPnlDollar,
       trades,

--- a/apps/trading-simulator/src/engine/portfolio.ts
+++ b/apps/trading-simulator/src/engine/portfolio.ts
@@ -1,0 +1,138 @@
+import type { ExecutedTrade, OhlcCandle, TradeSignal } from './types.js';
+
+interface OpenPosition {
+  entryPrice: number;
+  slPrice: number;
+  tpPrice: number;
+  side: 'LONG' | 'SHORT';
+  leverage: number;
+  dollarRisk: number;
+  entryTimestamp: Date;
+  metadata: Record<string, unknown>;
+}
+
+/**
+ * Tracks account balance and manages a single open position at a time.
+ *
+ * P&L is computed relative to `dollarRisk` (the max loss if SL is hit):
+ *   - SL hit  → pnlDollar = -dollarRisk
+ *   - TP hit  → pnlDollar = dollarRisk × (tp_distance / sl_distance)
+ */
+export class Portfolio {
+  private balance: number;
+  private position: OpenPosition | null = null;
+  private readonly completedTrades: ExecutedTrade[] = [];
+  private tradeIdCounter = 0;
+
+  constructor(initialBalance: number) {
+    this.balance = initialBalance;
+  }
+
+  // ── Position lifecycle ──────────────────────────────────────────────────────
+
+  openPosition(signal: TradeSignal): void {
+    if (this.position !== null) {
+      throw new Error('Cannot open position: close the existing position first');
+    }
+    this.position = {
+      entryPrice: signal.entryPrice,
+      slPrice: signal.slPrice,
+      tpPrice: signal.tpPrice,
+      side: signal.direction,
+      leverage: signal.leverage,
+      dollarRisk: signal.dollarRisk,
+      entryTimestamp: new Date(),
+      metadata: signal.metadata,
+    };
+  }
+
+  /**
+   * Check whether the stop-loss was hit on this candle.
+   * If hit, the position is closed and the trade is recorded.
+   * Returns true if SL was hit.
+   */
+  checkStopLoss(candle: OhlcCandle): boolean {
+    if (!this.position) return false;
+    const { side, slPrice } = this.position;
+    const hit = side === 'LONG' ? candle.low <= slPrice : candle.high >= slPrice;
+    if (hit) this.closePosition(slPrice, 'SL', candle.open_time);
+    return hit;
+  }
+
+  /**
+   * Check whether the take-profit was hit on this candle.
+   * If hit, the position is closed and the trade is recorded.
+   * Returns true if TP was hit.
+   */
+  checkTakeProfit(candle: OhlcCandle): boolean {
+    if (!this.position) return false;
+    const { side, tpPrice } = this.position;
+    const hit = side === 'LONG' ? candle.high >= tpPrice : candle.low <= tpPrice;
+    if (hit) this.closePosition(tpPrice, 'TP', candle.open_time);
+    return hit;
+  }
+
+  /**
+   * Manually close the current position at `exitPrice`.
+   * Returns the completed trade, or null if no position is open.
+   */
+  closePosition(
+    exitPrice: number,
+    exitReason: 'SL' | 'TP',
+    exitTimestamp?: number,
+  ): ExecutedTrade | null {
+    if (!this.position) return null;
+
+    const { entryPrice, slPrice, tpPrice, side, leverage, dollarRisk, metadata } = this.position;
+
+    const slDistance =
+      side === 'LONG' ? entryPrice - slPrice : slPrice - entryPrice;
+
+    const exitDistance =
+      side === 'LONG' ? exitPrice - entryPrice : entryPrice - exitPrice;
+
+    const pnlDollar =
+      slDistance > 0 ? dollarRisk * (exitDistance / slDistance) : 0;
+
+    const pnlPercent = this.balance > 0 ? (pnlDollar / this.balance) * 100 : 0;
+
+    const trade: ExecutedTrade = {
+      id: ++this.tradeIdCounter,
+      timestamp: exitTimestamp ? new Date(exitTimestamp) : new Date(),
+      direction: side,
+      entryPrice,
+      slPrice,
+      tpPrice,
+      exitPrice,
+      exitReason,
+      pnlPercent,
+      pnlDollar,
+      leverage,
+      metadata,
+    };
+
+    this.balance += pnlDollar;
+    this.completedTrades.push(trade);
+    this.position = null;
+
+    return trade;
+  }
+
+  // ── Queries ─────────────────────────────────────────────────────────────────
+
+  hasOpenPosition(): boolean {
+    return this.position !== null;
+  }
+
+  getOpenPosition(): OpenPosition | null {
+    return this.position;
+  }
+
+  getBalance(): number {
+    return this.balance;
+  }
+
+  getTrades(): ExecutedTrade[] {
+    return this.completedTrades;
+  }
+}

--- a/apps/trading-simulator/src/engine/portfolio.ts
+++ b/apps/trading-simulator/src/engine/portfolio.ts
@@ -30,7 +30,7 @@ export class Portfolio {
 
   // ── Position lifecycle ──────────────────────────────────────────────────────
 
-  openPosition(signal: TradeSignal): void {
+  openPosition(signal: TradeSignal, entryTimestamp: number): void {
     if (this.position !== null) {
       throw new Error('Cannot open position: close the existing position first');
     }
@@ -41,7 +41,7 @@ export class Portfolio {
       side: signal.direction,
       leverage: signal.leverage,
       dollarRisk: signal.dollarRisk,
-      entryTimestamp: new Date(),
+      entryTimestamp: new Date(entryTimestamp),
       metadata: signal.metadata,
     };
   }
@@ -83,7 +83,7 @@ export class Portfolio {
   ): ExecutedTrade | null {
     if (!this.position) return null;
 
-    const { entryPrice, slPrice, tpPrice, side, leverage, dollarRisk, metadata } = this.position;
+    const { entryPrice, slPrice, tpPrice, side, leverage, dollarRisk, entryTimestamp, metadata } = this.position;
 
     const slDistance =
       side === 'LONG' ? entryPrice - slPrice : slPrice - entryPrice;
@@ -96,9 +96,13 @@ export class Portfolio {
 
     const pnlPercent = this.balance > 0 ? (pnlDollar / this.balance) * 100 : 0;
 
+    // Note: `leverage` is stored as metadata only — it is not applied to position
+    // sizing here. P&L is driven entirely by dollarRisk and price distance, so
+    // strategies must bake leverage into dollarRisk themselves if needed.
     const trade: ExecutedTrade = {
       id: ++this.tradeIdCounter,
-      timestamp: exitTimestamp ? new Date(exitTimestamp) : new Date(),
+      entryTimestamp,
+      exitTimestamp: exitTimestamp ? new Date(exitTimestamp) : new Date(),
       direction: side,
       entryPrice,
       slPrice,

--- a/apps/trading-simulator/src/engine/portfolio.ts
+++ b/apps/trading-simulator/src/engine/portfolio.ts
@@ -79,7 +79,7 @@ export class Portfolio {
   closePosition(
     exitPrice: number,
     exitReason: 'SL' | 'TP',
-    exitTimestamp?: number,
+    exitTimestamp: number,
   ): ExecutedTrade | null {
     if (!this.position) return null;
 
@@ -102,7 +102,7 @@ export class Portfolio {
     const trade: ExecutedTrade = {
       id: ++this.tradeIdCounter,
       entryTimestamp,
-      exitTimestamp: exitTimestamp ? new Date(exitTimestamp) : new Date(),
+      exitTimestamp: new Date(exitTimestamp),
       direction: side,
       entryPrice,
       slPrice,

--- a/apps/trading-simulator/src/engine/time-machine.ts
+++ b/apps/trading-simulator/src/engine/time-machine.ts
@@ -1,0 +1,58 @@
+import type { OhlcCandle } from './types.js';
+
+/**
+ * Iterates through a historical candle array in a sliding 3-candle window
+ * [c1, c2, c3], advancing one candle at a time to simulate real-time
+ * progression.
+ */
+export class TimeMachine {
+  private readonly candles: OhlcCandle[];
+  /** Index of the c3 (most recent) candle in the next window to return. */
+  private pos: number = 2;
+
+  constructor(candles: OhlcCandle[]) {
+    if (candles.length < 3) {
+      throw new Error(`TimeMachine requires at least 3 candles, got ${candles.length}`);
+    }
+    this.candles = candles;
+  }
+
+  /**
+   * Advance to the next candle and return the new [c1, c2, c3] window,
+   * or null if all candles have been consumed.
+   */
+  next(): [OhlcCandle, OhlcCandle, OhlcCandle] | null {
+    if (this.pos >= this.candles.length) return null;
+
+    const window: [OhlcCandle, OhlcCandle, OhlcCandle] = [
+      this.candles[this.pos - 2]!,
+      this.candles[this.pos - 1]!,
+      this.candles[this.pos]!,
+    ];
+    this.pos++;
+    return window;
+  }
+
+  /**
+   * Current position as a human-readable string, e.g. "75,384 / 105,120".
+   * The first number is the 1-based index of the last returned c3 candle.
+   */
+  progress(): string {
+    const current = Math.min(this.pos, this.candles.length);
+    return `${current.toLocaleString()} / ${this.candles.length.toLocaleString()}`;
+  }
+
+  /**
+   * Unix timestamp (ms) of the c3 candle from the most recently returned window.
+   * Returns 0 before the first call to next().
+   */
+  currentTimestamp(): number {
+    if (this.pos <= 2) return 0;
+    return this.candles[this.pos - 1]!.open_time;
+  }
+
+  /** Total number of candles loaded. */
+  get total(): number {
+    return this.candles.length;
+  }
+}

--- a/apps/trading-simulator/src/engine/types.ts
+++ b/apps/trading-simulator/src/engine/types.ts
@@ -31,7 +31,8 @@ export interface TradeSignal {
 
 export interface ExecutedTrade {
   id: number;
-  timestamp: Date;
+  entryTimestamp: Date;
+  exitTimestamp: Date;
   direction: 'LONG' | 'SHORT';
   entryPrice: number;
   slPrice: number;
@@ -66,6 +67,8 @@ export interface BacktestResults {
   totalTrades: number;
   winCount: number;
   lossCount: number;
+  /** Trades where pnlDollar === 0 (not counted in winCount or lossCount). */
+  breakEvenCount: number;
   winRate: number;
   totalPnlDollar: number;
   trades: ExecutedTrade[];

--- a/apps/trading-simulator/src/engine/types.ts
+++ b/apps/trading-simulator/src/engine/types.ts
@@ -1,0 +1,72 @@
+import type { OhlcCandle as BaseOhlcCandle } from '@crypto-terminal/trade-formula';
+
+// ── Candle ────────────────────────────────────────────────────────────────────
+
+/**
+ * A single OHLC candle as stored in ohlcv_candles, extending the trade-formula
+ * base type with the timestamp and extra exchange fields.
+ */
+export interface OhlcCandle extends BaseOhlcCandle {
+  /** Unix timestamp in milliseconds (bigint stored as number) */
+  open_time: number;
+  volume: number;
+  quote_volume: number;
+  num_trades: number;
+}
+
+// ── Strategy output ───────────────────────────────────────────────────────────
+
+export interface TradeSignal {
+  direction: 'LONG' | 'SHORT';
+  entryPrice: number;
+  slPrice: number;
+  tpPrice: number;
+  leverage: number;
+  dollarRisk: number;
+  /** Strategy-specific supplementary data */
+  metadata: Record<string, unknown>;
+}
+
+// ── Completed trade ───────────────────────────────────────────────────────────
+
+export interface ExecutedTrade {
+  id: number;
+  timestamp: Date;
+  direction: 'LONG' | 'SHORT';
+  entryPrice: number;
+  slPrice: number;
+  tpPrice: number;
+  exitPrice: number;
+  exitReason: 'SL' | 'TP';
+  pnlPercent: number;
+  pnlDollar: number;
+  leverage: number;
+  metadata: Record<string, unknown>;
+}
+
+// ── Strategy contract ─────────────────────────────────────────────────────────
+
+export interface StrategyRunner {
+  name: string;
+  version: string;
+  /**
+   * Analyse the current 3-candle window and return a trade signal,
+   * or null to skip this bar.
+   */
+  analyze(candles: [OhlcCandle, OhlcCandle, OhlcCandle]): TradeSignal | null;
+  /** Called after every completed trade so the strategy can update internal state. */
+  onTradeExecuted(trade: ExecutedTrade): void;
+}
+
+// ── Backtest results ──────────────────────────────────────────────────────────
+
+export interface BacktestResults {
+  initialBalance: number;
+  finalBalance: number;
+  totalTrades: number;
+  winCount: number;
+  lossCount: number;
+  winRate: number;
+  totalPnlDollar: number;
+  trades: ExecutedTrade[];
+}

--- a/apps/trading-simulator/src/index.ts
+++ b/apps/trading-simulator/src/index.ts
@@ -1,0 +1,120 @@
+import pg from 'pg';
+import pino from 'pino';
+import { config } from './config.js';
+import { createDb } from './db/client.js';
+import { fetchAllCandles } from './db/queries.js';
+import { BacktestRunner } from './engine/backtest-runner.js';
+import type { ExecutedTrade, OhlcCandle, StrategyRunner, TradeSignal } from './engine/types.js';
+
+const log = pino({ level: config.logLevel });
+const { Pool } = pg;
+
+// ── Parse CLI args ────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+const strategyArg = args.find((a) => a.startsWith('--strategy='))?.split('=')[1] ?? 'dummy';
+
+// ── Dummy strategy (no-op — always returns null) ──────────────────────────────
+
+const dummyStrategy: StrategyRunner = {
+  name: 'dummy',
+  version: '0.0.1',
+  analyze(_candles: [OhlcCandle, OhlcCandle, OhlcCandle]): TradeSignal | null {
+    return null;
+  },
+  onTradeExecuted(_trade: ExecutedTrade): void {
+    // no-op
+  },
+};
+
+function resolveStrategy(name: string): StrategyRunner {
+  if (name === 'dummy') return dummyStrategy;
+  log.error({ strategy: name }, '[cli] Unknown strategy');
+  process.exit(1);
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const pool = new Pool({ connectionString: config.database.url });
+
+  try {
+    try {
+      const client = await pool.connect();
+      await client.query('SELECT 1');
+      client.release();
+      log.info('[db] Database connection established');
+    } catch (err) {
+      log.error({ err }, '[db] Failed to connect to database');
+      process.exit(1);
+    }
+
+    const db = createDb(pool);
+
+    log.info(
+      { instrument: config.instrument, timeframe: config.timeframe },
+      '[backtest] Fetching candles',
+    );
+
+    const candles = await fetchAllCandles(db, config.instrument, config.timeframe);
+
+    log.info({ count: candles.length }, '[backtest] Candles loaded');
+
+    if (candles.length < 3) {
+      log.error({ count: candles.length }, '[backtest] Not enough candles to run a backtest');
+      process.exit(1);
+    }
+
+    const strategy = resolveStrategy(strategyArg);
+
+    log.info(
+      {
+        strategy: strategy.name,
+        version: strategy.version,
+        initialBalance: config.initialBalance,
+      },
+      '[backtest] Starting',
+    );
+
+    const runner = new BacktestRunner({
+      candles,
+      strategy,
+      initialBalance: config.initialBalance,
+    });
+
+    runner.on('tradeClosed', (trade) => {
+      log.info(
+        {
+          id: trade.id,
+          direction: trade.direction,
+          exitReason: trade.exitReason,
+          pnlDollar: trade.pnlDollar.toFixed(2),
+          pnlPercent: trade.pnlPercent.toFixed(2),
+        },
+        '[trade] Closed',
+      );
+    });
+
+    const results = await runner.run();
+
+    log.info(
+      {
+        initialBalance: results.initialBalance.toFixed(2),
+        finalBalance: results.finalBalance.toFixed(2),
+        totalPnl: results.totalPnlDollar.toFixed(2),
+        totalTrades: results.totalTrades,
+        wins: results.winCount,
+        losses: results.lossCount,
+        winRate: `${results.winRate.toFixed(1)}%`,
+      },
+      '[backtest] Complete',
+    );
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  log.error({ err }, '[backtest] Unrecoverable error');
+  process.exit(1);
+});

--- a/apps/trading-simulator/src/index.ts
+++ b/apps/trading-simulator/src/index.ts
@@ -56,6 +56,8 @@ async function main() {
       '[backtest] Fetching candles',
     );
 
+    const strategy = resolveStrategy(strategyArg);
+
     const candles = await fetchAllCandles(db, config.instrument, config.timeframe);
 
     log.info({ count: candles.length }, '[backtest] Candles loaded');
@@ -64,8 +66,6 @@ async function main() {
       log.error({ count: candles.length }, '[backtest] Not enough candles to run a backtest');
       process.exit(1);
     }
-
-    const strategy = resolveStrategy(strategyArg);
 
     log.info(
       {
@@ -95,7 +95,7 @@ async function main() {
       );
     });
 
-    const results = await runner.run();
+    const results = runner.run();
 
     log.info(
       {

--- a/apps/trading-simulator/src/index.ts
+++ b/apps/trading-simulator/src/index.ts
@@ -51,12 +51,12 @@ async function main() {
 
     const db = createDb(pool);
 
+    const strategy = resolveStrategy(strategyArg);
+
     log.info(
       { instrument: config.instrument, timeframe: config.timeframe },
       '[backtest] Fetching candles',
     );
-
-    const strategy = resolveStrategy(strategyArg);
 
     const candles = await fetchAllCandles(db, config.instrument, config.timeframe);
 

--- a/apps/trading-simulator/tsconfig.json
+++ b/apps/trading-simulator/tsconfig.json
@@ -7,8 +7,7 @@
     "rootDir": "src",
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true,
-    "declaration": true
+    "skipLibCheck": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/apps/trading-simulator/tsconfig.json
+++ b/apps/trading-simulator/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Scaffolds the `apps/trading-simulator` app with all core backtest components: DB layer (ohlcv_candles + pattern_probabilities read-only schemas), TimeMachine iterator, Portfolio tracker, BacktestRunner orchestration loop, and CLI entry point.

Closes #50

Generated with [Claude Code](https://claude.ai/code)