### PR TITLE
Implement shared utilities for trading simulator backtesting

### DIFF
--- a/.github/workflows/opencode-review
+++ b/.github/workflows/opencode-review
@@ -1,0 +1,30 @@
+name: opencode-review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
+      issues: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: anomalyco/opencode/github@latest
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          model: opencode/minimax-m2.5-free
+          use_github_token: true
+          prompt: |
+            Review this pull request:
+            - Check for code quality issues
+            - Look for potential bugs
+            - Suggest improvements

--- a/apps/trading-simulator/src/shared/execution-log.ts
+++ b/apps/trading-simulator/src/shared/execution-log.ts
@@ -6,7 +6,18 @@ import type { LoggedTrade } from './types.js';
 
 export interface TradeLog {
   logTrade(trade: ExecutedTrade, strategyName: string, strategyVersion: string): void;
+  /**
+   * Returns a shallow copy of the internal trade array.
+   * The array itself is a new instance, but the individual `LoggedTrade`
+   * objects are shared references — mutating a returned trade object will
+   * corrupt the log's internal state.
+   */
   getAllTrades(): LoggedTrade[];
+  /**
+   * Returns trades filtered by strategy name.
+   * Note: returned `LoggedTrade` objects are shared references to the
+   * internal log entries — do not mutate them.
+   */
   getTradesByStrategy(strategyName: string): LoggedTrade[];
   clearLog(): void;
   exportToJSON(filepath: string): void;

--- a/apps/trading-simulator/src/shared/execution-log.ts
+++ b/apps/trading-simulator/src/shared/execution-log.ts
@@ -96,7 +96,15 @@ export class InMemoryTradeLog implements TradeLog {
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function csvEscape(value: string): string {
-  if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+  // Quote values that contain special CSV characters OR start with formula
+  // trigger characters (=, +, -, @) to prevent formula injection when the
+  // file is opened in spreadsheet applications.
+  if (
+    value.includes(',') ||
+    value.includes('"') ||
+    value.includes('\n') ||
+    /^[=+\-@]/.test(value)
+  ) {
     return `"${value.replace(/"/g, '""')}"`;
   }
   return value;

--- a/apps/trading-simulator/src/shared/execution-log.ts
+++ b/apps/trading-simulator/src/shared/execution-log.ts
@@ -1,0 +1,103 @@
+import { writeFileSync } from 'node:fs';
+import type { ExecutedTrade } from '../engine/types.js';
+import type { LoggedTrade } from './types.js';
+
+// ── TradeLog interface ────────────────────────────────────────────────────────
+
+export interface TradeLog {
+  logTrade(trade: ExecutedTrade, strategyName: string, strategyVersion: string): void;
+  getAllTrades(): LoggedTrade[];
+  getTradesByStrategy(strategyName: string): LoggedTrade[];
+  clearLog(): void;
+  exportToJSON(filepath: string): void;
+  exportToCSV(filepath: string): void;
+}
+
+// ── In-memory implementation ──────────────────────────────────────────────────
+
+/**
+ * In-memory trade log for backtest audit trails.
+ *
+ * Stores all executed trades in an array annotated with the strategy that
+ * produced them. Export to JSON/CSV for offline analysis.
+ */
+export class InMemoryTradeLog implements TradeLog {
+  private trades: LoggedTrade[] = [];
+
+  logTrade(trade: ExecutedTrade, strategyName: string, strategyVersion: string): void {
+    this.trades.push({ ...trade, strategyName, strategyVersion });
+  }
+
+  getAllTrades(): LoggedTrade[] {
+    return [...this.trades];
+  }
+
+  getTradesByStrategy(strategyName: string): LoggedTrade[] {
+    return this.trades.filter((t) => t.strategyName === strategyName);
+  }
+
+  clearLog(): void {
+    this.trades = [];
+  }
+
+  exportToJSON(filepath: string): void {
+    writeFileSync(filepath, JSON.stringify(this.trades, null, 2), 'utf-8');
+  }
+
+  exportToCSV(filepath: string): void {
+    if (this.trades.length === 0) {
+      writeFileSync(filepath, '', 'utf-8');
+      return;
+    }
+
+    const headers = [
+      'id',
+      'strategyName',
+      'strategyVersion',
+      'entryTimestamp',
+      'exitTimestamp',
+      'direction',
+      'entryPrice',
+      'slPrice',
+      'tpPrice',
+      'exitPrice',
+      'exitReason',
+      'pnlPercent',
+      'pnlDollar',
+      'leverage',
+      'metadata',
+    ];
+
+    const rows = this.trades.map((t) => {
+      const cells = [
+        t.id,
+        csvEscape(t.strategyName),
+        csvEscape(t.strategyVersion),
+        t.entryTimestamp.toISOString(),
+        t.exitTimestamp.toISOString(),
+        t.direction,
+        t.entryPrice,
+        t.slPrice,
+        t.tpPrice,
+        t.exitPrice,
+        t.exitReason,
+        t.pnlPercent,
+        t.pnlDollar,
+        t.leverage,
+        csvEscape(JSON.stringify(t.metadata)),
+      ];
+      return cells.join(',');
+    });
+
+    writeFileSync(filepath, [headers.join(','), ...rows].join('\n'), 'utf-8');
+  }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function csvEscape(value: string): string {
+  if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}

--- a/apps/trading-simulator/src/shared/metrics.ts
+++ b/apps/trading-simulator/src/shared/metrics.ts
@@ -119,10 +119,10 @@ export function sharpeRatio(trades: ExecutedTrade[], riskFreeRate = 0): number {
  */
 export function profitFactor(trades: ExecutedTrade[]): number {
   const grossProfit = trades
-    .filter((t) => t.pnlDollar > 0)
-    .reduce((s, t) => s + t.pnlDollar, 0);
+    .filter((t) => t.pnlPercent > 0)
+    .reduce((s, t) => s + t.pnlPercent, 0);
   const grossLoss = Math.abs(
-    trades.filter((t) => t.pnlDollar < 0).reduce((s, t) => s + t.pnlDollar, 0),
+    trades.filter((t) => t.pnlPercent < 0).reduce((s, t) => s + t.pnlPercent, 0),
   );
 
   if (grossLoss === 0) return grossProfit > 0 ? Infinity : 0;

--- a/apps/trading-simulator/src/shared/metrics.ts
+++ b/apps/trading-simulator/src/shared/metrics.ts
@@ -1,0 +1,230 @@
+import type { ExecutedTrade } from '../engine/types.js';
+import type { EquityPoint } from './types.js';
+
+// ── PerformanceMetrics interface ──────────────────────────────────────────────
+
+export interface PerformanceMetrics {
+  totalTrades: number;
+  winningTrades: number;
+  losingTrades: number;
+  /** Percentage of trades that are wins (0–100). */
+  winRate: number;
+  /** Total P&L as a percentage of initialBalance. */
+  totalPnL: number;
+
+  /** Maximum peak-to-trough equity decline as a percentage (negative). */
+  maxDrawdown: number;
+  sharpeRatio: number;
+  profitFactor: number;
+  /** Average P&L per trade in percentage. */
+  expectedValue: number;
+
+  /** Average winning trade P&L in percentage. */
+  averageWin: number;
+  /** Average losing trade P&L in percentage (negative). */
+  averageLoss: number;
+  /** Largest single winning trade P&L in percentage. */
+  largestWin: number;
+  /** Largest single losing trade P&L in percentage (negative). */
+  largestLoss: number;
+  /** Average time between entry and exit across all trades, in hours. */
+  averageHoldTime: number;
+
+  equityCurve: EquityPoint[];
+}
+
+// ── Annualization constant for 5-minute candles ───────────────────────────────
+
+// 288 candles per day × 365 days — used to annualize the per-trade Sharpe ratio.
+const ANNUALIZATION_FACTOR = Math.sqrt(288 * 365);
+
+// ── Individual metric functions ───────────────────────────────────────────────
+
+export function totalTrades(trades: ExecutedTrade[]): number {
+  return trades.length;
+}
+
+export function winningTrades(trades: ExecutedTrade[]): number {
+  return trades.filter((t) => t.pnlPercent > 0).length;
+}
+
+export function losingTrades(trades: ExecutedTrade[]): number {
+  return trades.filter((t) => t.pnlPercent < 0).length;
+}
+
+/** Returns win rate as a percentage (0–100). Returns 0 for empty trade arrays. */
+export function winRate(trades: ExecutedTrade[]): number {
+  if (trades.length === 0) return 0;
+  return (winningTrades(trades) / trades.length) * 100;
+}
+
+/** Total P&L as a percentage of initialBalance. Returns 0 if initialBalance is 0. */
+export function totalPnLPercent(trades: ExecutedTrade[], initialBalance: number): number {
+  if (initialBalance === 0) return 0;
+  const dollarPnL = trades.reduce((sum, t) => sum + t.pnlDollar, 0);
+  return (dollarPnL / initialBalance) * 100;
+}
+
+/**
+ * Maximum peak-to-trough equity decline as a percentage (always ≤ 0).
+ * Returns 0 for empty trade arrays.
+ */
+export function maxDrawdown(trades: ExecutedTrade[], initialBalance: number): number {
+  if (trades.length === 0) return 0;
+
+  let peak = initialBalance;
+  let maxDd = 0;
+  let balance = initialBalance;
+
+  for (const trade of trades) {
+    balance += trade.pnlDollar;
+    if (balance > peak) {
+      peak = balance;
+    }
+    if (peak > 0) {
+      const dd = ((balance - peak) / peak) * 100;
+      if (dd < maxDd) {
+        maxDd = dd;
+      }
+    }
+  }
+
+  return maxDd;
+}
+
+/**
+ * Annualized Sharpe ratio based on per-trade P&L percentages.
+ *
+ * Annualization factor assumes 5-minute candles (288 per day, 365 days/year).
+ * Returns 0 when fewer than 2 trades exist or standard deviation is 0.
+ */
+export function sharpeRatio(trades: ExecutedTrade[], riskFreeRate = 0): number {
+  if (trades.length < 2) return 0;
+
+  const returns = trades.map((t) => t.pnlPercent);
+  const avgReturn = returns.reduce((s, r) => s + r, 0) / returns.length;
+  const variance =
+    returns.reduce((s, r) => s + (r - avgReturn) ** 2, 0) / (returns.length - 1);
+  const stdDev = Math.sqrt(variance);
+
+  if (stdDev === 0) return 0;
+
+  return ((avgReturn - riskFreeRate) / stdDev) * ANNUALIZATION_FACTOR;
+}
+
+/**
+ * Profit factor: gross profit divided by gross loss.
+ * Returns Infinity when there are no losing trades but some winning trades.
+ * Returns 0 when there are no winning trades (or no trades at all).
+ */
+export function profitFactor(trades: ExecutedTrade[]): number {
+  const grossProfit = trades
+    .filter((t) => t.pnlDollar > 0)
+    .reduce((s, t) => s + t.pnlDollar, 0);
+  const grossLoss = Math.abs(
+    trades.filter((t) => t.pnlDollar < 0).reduce((s, t) => s + t.pnlDollar, 0),
+  );
+
+  if (grossLoss === 0) return grossProfit > 0 ? Infinity : 0;
+  return grossProfit / grossLoss;
+}
+
+/** Average P&L per trade in percentage. Returns 0 for empty trade arrays. */
+export function expectedValue(trades: ExecutedTrade[]): number {
+  if (trades.length === 0) return 0;
+  return trades.reduce((s, t) => s + t.pnlPercent, 0) / trades.length;
+}
+
+/** Average winning trade P&L in percentage. Returns 0 when no wins exist. */
+export function averageWin(trades: ExecutedTrade[]): number {
+  const wins = trades.filter((t) => t.pnlPercent > 0);
+  if (wins.length === 0) return 0;
+  return wins.reduce((s, t) => s + t.pnlPercent, 0) / wins.length;
+}
+
+/** Average losing trade P&L in percentage (negative). Returns 0 when no losses exist. */
+export function averageLoss(trades: ExecutedTrade[]): number {
+  const losses = trades.filter((t) => t.pnlPercent < 0);
+  if (losses.length === 0) return 0;
+  return losses.reduce((s, t) => s + t.pnlPercent, 0) / losses.length;
+}
+
+/** Largest single win P&L in percentage. Returns 0 when no wins exist. */
+export function largestWin(trades: ExecutedTrade[]): number {
+  const wins = trades.filter((t) => t.pnlPercent > 0);
+  if (wins.length === 0) return 0;
+  return Math.max(...wins.map((t) => t.pnlPercent));
+}
+
+/** Largest single loss P&L in percentage (negative). Returns 0 when no losses exist. */
+export function largestLoss(trades: ExecutedTrade[]): number {
+  const losses = trades.filter((t) => t.pnlPercent < 0);
+  if (losses.length === 0) return 0;
+  return Math.min(...losses.map((t) => t.pnlPercent));
+}
+
+/** Average hold time across all trades, in hours. Returns 0 for empty trade arrays. */
+export function averageHoldTime(trades: ExecutedTrade[]): number {
+  if (trades.length === 0) return 0;
+  const totalMs = trades.reduce(
+    (s, t) => s + (t.exitTimestamp.getTime() - t.entryTimestamp.getTime()),
+    0,
+  );
+  return totalMs / trades.length / 3_600_000;
+}
+
+/**
+ * Build an equity curve from the trade list.
+ *
+ * The first point uses the entry timestamp of the first trade (or current time
+ * if the array is empty) at initialBalance. Each subsequent point is appended
+ * after each trade closes.
+ */
+export function buildEquityCurve(
+  trades: ExecutedTrade[],
+  initialBalance: number,
+): EquityPoint[] {
+  const startTime = trades.length > 0 ? trades[0].entryTimestamp : new Date();
+  const curve: EquityPoint[] = [{ timestamp: startTime, balance: initialBalance }];
+
+  let balance = initialBalance;
+  for (const trade of trades) {
+    balance += trade.pnlDollar;
+    curve.push({ timestamp: trade.exitTimestamp, balance });
+  }
+
+  return curve;
+}
+
+// ── Aggregate function ────────────────────────────────────────────────────────
+
+/**
+ * Compute all performance metrics from a list of executed trades.
+ *
+ * @param trades         Completed trades in chronological order.
+ * @param initialBalance Starting account balance in USD.
+ * @param riskFreeRate   Per-trade risk-free return for Sharpe ratio (default 0).
+ */
+export function calculateMetrics(
+  trades: ExecutedTrade[],
+  initialBalance: number,
+  riskFreeRate = 0,
+): PerformanceMetrics {
+  return {
+    totalTrades: totalTrades(trades),
+    winningTrades: winningTrades(trades),
+    losingTrades: losingTrades(trades),
+    winRate: winRate(trades),
+    totalPnL: totalPnLPercent(trades, initialBalance),
+    maxDrawdown: maxDrawdown(trades, initialBalance),
+    sharpeRatio: sharpeRatio(trades, riskFreeRate),
+    profitFactor: profitFactor(trades),
+    expectedValue: expectedValue(trades),
+    averageWin: averageWin(trades),
+    averageLoss: averageLoss(trades),
+    largestWin: largestWin(trades),
+    largestLoss: largestLoss(trades),
+    averageHoldTime: averageHoldTime(trades),
+    equityCurve: buildEquityCurve(trades, initialBalance),
+  };
+}

--- a/apps/trading-simulator/src/shared/metrics.ts
+++ b/apps/trading-simulator/src/shared/metrics.ts
@@ -36,6 +36,9 @@ export interface PerformanceMetrics {
 // ── Annualization constant for 5-minute candles ───────────────────────────────
 
 // 288 candles per day × 365 days — used to annualize the per-trade Sharpe ratio.
+// IMPORTANT: This value is hardcoded for 5-minute candle intervals. If the
+// backtest runner processes candles of a different interval, update this
+// constant accordingly (e.g. 96 for 15-minute, 24 for 1-hour candles).
 const ANNUALIZATION_FACTOR = Math.sqrt(288 * 365);
 
 // ── Individual metric functions ───────────────────────────────────────────────
@@ -96,9 +99,17 @@ export function maxDrawdown(trades: ExecutedTrade[], initialBalance: number): nu
  * Annualized Sharpe ratio based on per-trade P&L percentages.
  *
  * Annualization factor assumes 5-minute candles (288 per day, 365 days/year).
+ * If this function is called with trades from a different candle interval the
+ * annualized result will be incorrect — either adjust `ANNUALIZATION_FACTOR`
+ * at the top of this module or pass the result through without annualizing.
+ *
  * Returns 0 when fewer than 2 trades exist or standard deviation is 0.
+ *
+ * @param riskFreeReturnPercent Per-trade risk-free return expressed as a
+ *   percentage (e.g. `0.1` = 0.1% per trade), not an annualised rate.
+ *   Default is `0`.
  */
-export function sharpeRatio(trades: ExecutedTrade[], riskFreeRate = 0): number {
+export function sharpeRatio(trades: ExecutedTrade[], riskFreeReturnPercent = 0): number {
   if (trades.length < 2) return 0;
 
   const returns = trades.map((t) => t.pnlPercent);
@@ -109,7 +120,7 @@ export function sharpeRatio(trades: ExecutedTrade[], riskFreeRate = 0): number {
 
   if (stdDev === 0) return 0;
 
-  return ((avgReturn - riskFreeRate) / stdDev) * ANNUALIZATION_FACTOR;
+  return ((avgReturn - riskFreeReturnPercent) / stdDev) * ANNUALIZATION_FACTOR;
 }
 
 /**
@@ -176,15 +187,20 @@ export function averageHoldTime(trades: ExecutedTrade[]): number {
 /**
  * Build an equity curve from the trade list.
  *
- * The first point uses the entry timestamp of the first trade (or current time
- * if the array is empty) at initialBalance. Each subsequent point is appended
- * after each trade closes.
+ * The first point uses the entry timestamp of the first trade (or
+ * `startTimestamp` if provided) at initialBalance. Each subsequent point is
+ * appended after each trade closes.
+ *
+ * @param startTimestamp Explicit start timestamp for the initial equity point.
+ *   Used when `trades` is empty to produce a deterministic curve. Defaults to
+ *   the first trade's `entryTimestamp` when trades are present.
  */
 export function buildEquityCurve(
   trades: ExecutedTrade[],
   initialBalance: number,
+  startTimestamp?: Date,
 ): EquityPoint[] {
-  const startTime = trades.length > 0 ? trades[0].entryTimestamp : new Date();
+  const startTime = trades.length > 0 ? trades[0].entryTimestamp : (startTimestamp ?? new Date(0));
   const curve: EquityPoint[] = [{ timestamp: startTime, balance: initialBalance }];
 
   let balance = initialBalance;
@@ -201,14 +217,19 @@ export function buildEquityCurve(
 /**
  * Compute all performance metrics from a list of executed trades.
  *
- * @param trades         Completed trades in chronological order.
- * @param initialBalance Starting account balance in USD.
- * @param riskFreeRate   Per-trade risk-free return for Sharpe ratio (default 0).
+ * @param trades               Completed trades in chronological order.
+ * @param initialBalance       Starting account balance in USD.
+ * @param riskFreeReturnPercent Per-trade risk-free return expressed as a
+ *   percentage (e.g. `0.1` = 0.1% per trade), not an annualised rate.
+ *   Default is `0`.
+ * @param startTimestamp       Explicit start timestamp for the equity curve's
+ *   initial point. Only relevant when `trades` is empty.
  */
 export function calculateMetrics(
   trades: ExecutedTrade[],
   initialBalance: number,
-  riskFreeRate = 0,
+  riskFreeReturnPercent = 0,
+  startTimestamp?: Date,
 ): PerformanceMetrics {
   return {
     totalTrades: totalTrades(trades),
@@ -217,7 +238,7 @@ export function calculateMetrics(
     winRate: winRate(trades),
     totalPnL: totalPnLPercent(trades, initialBalance),
     maxDrawdown: maxDrawdown(trades, initialBalance),
-    sharpeRatio: sharpeRatio(trades, riskFreeRate),
+    sharpeRatio: sharpeRatio(trades, riskFreeReturnPercent),
     profitFactor: profitFactor(trades),
     expectedValue: expectedValue(trades),
     averageWin: averageWin(trades),
@@ -225,6 +246,6 @@ export function calculateMetrics(
     largestWin: largestWin(trades),
     largestLoss: largestLoss(trades),
     averageHoldTime: averageHoldTime(trades),
-    equityCurve: buildEquityCurve(trades, initialBalance),
+    equityCurve: buildEquityCurve(trades, initialBalance, startTimestamp),
   };
 }

--- a/apps/trading-simulator/src/shared/pattern-display.ts
+++ b/apps/trading-simulator/src/shared/pattern-display.ts
@@ -1,0 +1,125 @@
+import type { CandleLabel } from '@crypto-terminal/trade-formula';
+import type { OhlcCandle } from '../engine/types.js';
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const CANDLE_WIDTH = 6;
+const WICK_ROW = '  ││  ';   // 6 chars: 2 spaces + ││ + 2 spaces
+const BULL_BODY = '██████';  // 6 full-block chars (bullish)
+const BEAR_BODY = '│    │';  // outlined body (bearish)
+const EMPTY_ROW = '      ';  // 6 spaces
+const COLUMN_GAP = '  ';     // separator between side-by-side candles
+
+// ── Normalization ─────────────────────────────────────────────────────────────
+
+/**
+ * Map a price to a row index within [0, height-1].
+ * Row 0 is the bottom of the display; row height-1 is the top.
+ * When globalHigh === globalLow all prices map to the midpoint row.
+ */
+function normalizePrice(
+  price: number,
+  globalLow: number,
+  globalHigh: number,
+  height: number,
+): number {
+  if (globalHigh === globalLow) return Math.floor(height / 2);
+  return Math.round(((price - globalLow) / (globalHigh - globalLow)) * (height - 1));
+}
+
+// ── Single candle renderer ────────────────────────────────────────────────────
+
+/**
+ * Render a single candle column within a shared price range.
+ *
+ * Rows are returned from top (index 0) to bottom (index height-1).
+ * Each row is exactly CANDLE_WIDTH characters wide.
+ */
+function renderCandleColumn(
+  candle: OhlcCandle,
+  globalLow: number,
+  globalHigh: number,
+  height: number,
+): string[] {
+  const isBullish = candle.close >= candle.open;
+  const bodyTop = Math.max(candle.open, candle.close);
+  const bodyBottom = Math.min(candle.open, candle.close);
+
+  const highRow = normalizePrice(candle.high, globalLow, globalHigh, height);
+  const lowRow = normalizePrice(candle.low, globalLow, globalHigh, height);
+  const bodyTopRow = normalizePrice(bodyTop, globalLow, globalHigh, height);
+  const bodyBottomRow = normalizePrice(bodyBottom, globalLow, globalHigh, height);
+
+  const lines: string[] = [];
+
+  // Iterate from top row (height-1) down to row 0, push one line per row.
+  for (let row = height - 1; row >= 0; row--) {
+    if (row >= bodyBottomRow && row <= bodyTopRow) {
+      lines.push(isBullish ? BULL_BODY : BEAR_BODY);
+    } else if (row >= lowRow && row <= highRow) {
+      lines.push(WICK_ROW);
+    } else {
+      lines.push(EMPTY_ROW);
+    }
+  }
+
+  return lines;
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Render a single OHLC candle as an ASCII art column.
+ *
+ * The candle is scaled so that the full wick range (low → high) fills the
+ * specified height. Returns an array of strings, one per line, top to bottom.
+ * Each string is {@link CANDLE_WIDTH} characters wide.
+ *
+ * @param candle  The OHLC candle to render.
+ * @param height  Total height in character rows (must be ≥ 1).
+ */
+export function renderCandle(candle: OhlcCandle, height: number): string[] {
+  return renderCandleColumn(candle, candle.low, candle.high, height);
+}
+
+/**
+ * Render three candles side by side, normalized to a shared price range.
+ *
+ * All candles are scaled against the global high/low of the window so that
+ * relative price levels are preserved across the three columns.
+ *
+ * Returns an array of strings, one per line, top to bottom. Each string is
+ * `3 × CANDLE_WIDTH + 2 × COLUMN_GAP` characters wide.
+ *
+ * @param candles  The three-candle window [oldest, middle, newest].
+ * @param height   Total height in character rows (must be ≥ 1).
+ */
+export function render3CandleWindow(
+  candles: [OhlcCandle, OhlcCandle, OhlcCandle],
+  height: number,
+): string[] {
+  const globalHigh = Math.max(...candles.map((c) => c.high));
+  const globalLow = Math.min(...candles.map((c) => c.low));
+
+  const cols = candles.map((c) => renderCandleColumn(c, globalLow, globalHigh, height));
+
+  return cols[0].map(
+    (_, i) => cols[0][i] + COLUMN_GAP + cols[1][i] + COLUMN_GAP + cols[2][i],
+  );
+}
+
+/**
+ * Format a three-label pattern tuple as a readable string.
+ *
+ * @example
+ * formatPattern(['up_weak', 'up_weak', 'up_medium'])
+ * // => "[up_weak, up_weak, up_medium]"
+ */
+export function formatPattern(
+  labels: [CandleLabel, CandleLabel, CandleLabel],
+): string {
+  return `[${labels.join(', ')}]`;
+}
+
+// Re-export for convenience
+export { CANDLE_WIDTH };

--- a/apps/trading-simulator/src/shared/types.ts
+++ b/apps/trading-simulator/src/shared/types.ts
@@ -1,0 +1,19 @@
+import type { ExecutedTrade } from '../engine/types.js';
+
+// ── Logged trade (ExecutedTrade + strategy identity) ──────────────────────────
+
+/**
+ * An executed trade annotated with the strategy that produced it.
+ * Used by InMemoryTradeLog to support multi-strategy audit trails.
+ */
+export interface LoggedTrade extends ExecutedTrade {
+  strategyName: string;
+  strategyVersion: string;
+}
+
+// ── Equity curve point ────────────────────────────────────────────────────────
+
+export interface EquityPoint {
+  timestamp: Date;
+  balance: number;
+}

--- a/apps/trading-simulator/tests/shared-execution-log.test.ts
+++ b/apps/trading-simulator/tests/shared-execution-log.test.ts
@@ -154,4 +154,23 @@ describe('InMemoryTradeLog — exportToCSV', () => {
     const content = readFileSync(file, 'utf-8');
     expect(content).toContain('"strategy,with,commas"');
   });
+
+  it('CSV values starting with formula trigger characters are quoted', () => {
+    const log = new InMemoryTradeLog();
+
+    for (const prefix of ['=', '+', '-', '@']) {
+      const stratName = `${prefix}SUM(A1:A10)`;
+      log.logTrade(makeTrade(), stratName, VERSION);
+    }
+
+    const file = join(tmpDir, 'formula.csv');
+    log.exportToCSV(file);
+
+    const content = readFileSync(file, 'utf-8');
+    // Each strategy name that starts with a formula trigger must be quoted
+    expect(content).toContain('"=SUM(A1:A10)"');
+    expect(content).toContain('"+SUM(A1:A10)"');
+    expect(content).toContain('"-SUM(A1:A10)"');
+    expect(content).toContain('"@SUM(A1:A10)"');
+  });
 });

--- a/apps/trading-simulator/tests/shared-execution-log.test.ts
+++ b/apps/trading-simulator/tests/shared-execution-log.test.ts
@@ -1,0 +1,157 @@
+import { mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { InMemoryTradeLog } from '../src/shared/execution-log.js';
+import type { ExecutedTrade } from '../src/engine/types.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeTrade(overrides: Partial<ExecutedTrade> = {}): ExecutedTrade {
+  return {
+    id: 1,
+    entryTimestamp: new Date('2026-01-01T00:00:00Z'),
+    exitTimestamp: new Date('2026-01-01T01:00:00Z'),
+    direction: 'LONG',
+    entryPrice: 100,
+    slPrice: 98,
+    tpPrice: 104,
+    exitPrice: 104,
+    exitReason: 'TP',
+    pnlPercent: 2,
+    pnlDollar: 20,
+    leverage: 5,
+    metadata: { route: 'Trend' },
+    ...overrides,
+  };
+}
+
+const STRATEGY_A = 'strategy-a';
+const STRATEGY_B = 'strategy-b';
+const VERSION = '1.0.0';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = join('/tmp', `trade-log-test-${Date.now()}`);
+  mkdirSync(tmpDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('InMemoryTradeLog — basic operations', () => {
+  it('starts empty', () => {
+    const log = new InMemoryTradeLog();
+    expect(log.getAllTrades()).toHaveLength(0);
+  });
+
+  it('logTrade adds a trade with strategy metadata', () => {
+    const log = new InMemoryTradeLog();
+    log.logTrade(makeTrade({ id: 1 }), STRATEGY_A, VERSION);
+
+    const trades = log.getAllTrades();
+    expect(trades).toHaveLength(1);
+    expect(trades[0].strategyName).toBe(STRATEGY_A);
+    expect(trades[0].strategyVersion).toBe(VERSION);
+    expect(trades[0].id).toBe(1);
+  });
+
+  it('getAllTrades returns a copy — mutations do not affect the log', () => {
+    const log = new InMemoryTradeLog();
+    log.logTrade(makeTrade(), STRATEGY_A, VERSION);
+
+    const trades = log.getAllTrades();
+    trades.push({ ...makeTrade({ id: 99 }), strategyName: STRATEGY_A, strategyVersion: VERSION });
+
+    expect(log.getAllTrades()).toHaveLength(1);
+  });
+
+  it('clearLog empties the store', () => {
+    const log = new InMemoryTradeLog();
+    log.logTrade(makeTrade(), STRATEGY_A, VERSION);
+    log.clearLog();
+    expect(log.getAllTrades()).toHaveLength(0);
+  });
+});
+
+describe('InMemoryTradeLog — getTradesByStrategy', () => {
+  it('filters trades by strategy name', () => {
+    const log = new InMemoryTradeLog();
+    log.logTrade(makeTrade({ id: 1 }), STRATEGY_A, VERSION);
+    log.logTrade(makeTrade({ id: 2 }), STRATEGY_B, VERSION);
+    log.logTrade(makeTrade({ id: 3 }), STRATEGY_A, VERSION);
+
+    const aOnly = log.getTradesByStrategy(STRATEGY_A);
+    expect(aOnly).toHaveLength(2);
+    expect(aOnly.every((t) => t.strategyName === STRATEGY_A)).toBe(true);
+  });
+
+  it('returns empty array for unknown strategy', () => {
+    const log = new InMemoryTradeLog();
+    log.logTrade(makeTrade(), STRATEGY_A, VERSION);
+    expect(log.getTradesByStrategy('unknown')).toHaveLength(0);
+  });
+});
+
+describe('InMemoryTradeLog — exportToJSON', () => {
+  it('writes valid JSON containing all trades', () => {
+    const log = new InMemoryTradeLog();
+    log.logTrade(makeTrade({ id: 1 }), STRATEGY_A, VERSION);
+    log.logTrade(makeTrade({ id: 2 }), STRATEGY_B, VERSION);
+
+    const file = join(tmpDir, 'trades.json');
+    log.exportToJSON(file);
+
+    const raw = readFileSync(file, 'utf-8');
+    const parsed = JSON.parse(raw);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0].id).toBe(1);
+  });
+
+  it('exports empty array JSON for empty log', () => {
+    const log = new InMemoryTradeLog();
+    const file = join(tmpDir, 'empty.json');
+    log.exportToJSON(file);
+
+    const parsed = JSON.parse(readFileSync(file, 'utf-8'));
+    expect(parsed).toEqual([]);
+  });
+});
+
+describe('InMemoryTradeLog — exportToCSV', () => {
+  it('writes empty string for empty log', () => {
+    const log = new InMemoryTradeLog();
+    const file = join(tmpDir, 'empty.csv');
+    log.exportToCSV(file);
+    expect(readFileSync(file, 'utf-8')).toBe('');
+  });
+
+  it('CSV has header row and one data row per trade', () => {
+    const log = new InMemoryTradeLog();
+    log.logTrade(makeTrade({ id: 1 }), STRATEGY_A, VERSION);
+
+    const file = join(tmpDir, 'trades.csv');
+    log.exportToCSV(file);
+
+    const lines = readFileSync(file, 'utf-8').split('\n');
+    expect(lines).toHaveLength(2); // header + 1 row
+    expect(lines[0]).toContain('id');
+    expect(lines[0]).toContain('strategyName');
+    expect(lines[1]).toContain(STRATEGY_A);
+  });
+
+  it('CSV values with commas are quoted', () => {
+    const log = new InMemoryTradeLog();
+    log.logTrade(makeTrade(), 'strategy,with,commas', VERSION);
+
+    const file = join(tmpDir, 'quoted.csv');
+    log.exportToCSV(file);
+
+    const content = readFileSync(file, 'utf-8');
+    expect(content).toContain('"strategy,with,commas"');
+  });
+});

--- a/apps/trading-simulator/tests/shared-metrics.test.ts
+++ b/apps/trading-simulator/tests/shared-metrics.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect, it } from 'vitest';
+import {
+  averageHoldTime,
+  averageLoss,
+  averageWin,
+  buildEquityCurve,
+  calculateMetrics,
+  expectedValue,
+  largestLoss,
+  largestWin,
+  losingTrades,
+  maxDrawdown,
+  profitFactor,
+  sharpeRatio,
+  totalPnLPercent,
+  totalTrades,
+  winRate,
+  winningTrades,
+} from '../src/shared/metrics.js';
+import type { ExecutedTrade } from '../src/engine/types.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeTrade(
+  pnlPercent: number,
+  pnlDollar: number,
+  opts: Partial<ExecutedTrade> = {},
+): ExecutedTrade {
+  return {
+    id: 1,
+    entryTimestamp: new Date('2026-01-01T00:00:00Z'),
+    exitTimestamp: new Date('2026-01-01T01:00:00Z'),
+    direction: 'LONG',
+    entryPrice: 100,
+    slPrice: 98,
+    tpPrice: 104,
+    exitPrice: pnlPercent >= 0 ? 104 : 98,
+    exitReason: pnlPercent >= 0 ? 'TP' : 'SL',
+    pnlPercent,
+    pnlDollar,
+    leverage: 5,
+    metadata: {},
+    ...opts,
+  };
+}
+
+const WIN = makeTrade(2, 20);
+const LOSS = makeTrade(-1, -10);
+const BREAKEVEN = makeTrade(0, 0);
+
+const SAMPLE_TRADES: ExecutedTrade[] = [
+  makeTrade(3, 30),
+  makeTrade(-1, -10),
+  makeTrade(2, 20),
+  makeTrade(-2, -20),
+  makeTrade(5, 50),
+];
+
+// ── Edge cases ────────────────────────────────────────────────────────────────
+
+describe('edge cases — empty trade array', () => {
+  it('totalTrades returns 0', () => expect(totalTrades([])).toBe(0));
+  it('winningTrades returns 0', () => expect(winningTrades([])).toBe(0));
+  it('losingTrades returns 0', () => expect(losingTrades([])).toBe(0));
+  it('winRate returns 0', () => expect(winRate([])).toBe(0));
+  it('totalPnLPercent returns 0', () => expect(totalPnLPercent([], 1000)).toBe(0));
+  it('maxDrawdown returns 0', () => expect(maxDrawdown([], 1000)).toBe(0));
+  it('sharpeRatio returns 0 for < 2 trades', () => expect(sharpeRatio([WIN])).toBe(0));
+  it('profitFactor returns 0 for empty', () => expect(profitFactor([])).toBe(0));
+  it('expectedValue returns 0', () => expect(expectedValue([])).toBe(0));
+  it('averageWin returns 0', () => expect(averageWin([])).toBe(0));
+  it('averageLoss returns 0', () => expect(averageLoss([])).toBe(0));
+  it('largestWin returns 0', () => expect(largestWin([])).toBe(0));
+  it('largestLoss returns 0', () => expect(largestLoss([])).toBe(0));
+  it('averageHoldTime returns 0', () => expect(averageHoldTime([])).toBe(0));
+});
+
+describe('edge cases — all wins', () => {
+  const allWins = [makeTrade(2, 20), makeTrade(3, 30), makeTrade(1, 10)];
+
+  it('losingTrades is 0', () => expect(losingTrades(allWins)).toBe(0));
+  it('winRate is 100', () => expect(winRate(allWins)).toBe(100));
+  it('profitFactor is Infinity', () => expect(profitFactor(allWins)).toBe(Infinity));
+  it('averageLoss is 0', () => expect(averageLoss(allWins)).toBe(0));
+  it('largestLoss is 0', () => expect(largestLoss(allWins)).toBe(0));
+});
+
+describe('edge cases — all losses', () => {
+  const allLosses = [makeTrade(-1, -10), makeTrade(-2, -20), makeTrade(-3, -30)];
+
+  it('winningTrades is 0', () => expect(winningTrades(allLosses)).toBe(0));
+  it('winRate is 0', () => expect(winRate(allLosses)).toBe(0));
+  it('profitFactor is 0', () => expect(profitFactor(allLosses)).toBe(0));
+  it('averageWin is 0', () => expect(averageWin(allLosses)).toBe(0));
+  it('largestWin is 0', () => expect(largestWin(allLosses)).toBe(0));
+  it('maxDrawdown is negative', () => expect(maxDrawdown(allLosses, 1000)).toBeLessThan(0));
+});
+
+// ── Correctness tests ─────────────────────────────────────────────────────────
+
+describe('totalTrades', () => {
+  it('counts all trades', () => expect(totalTrades(SAMPLE_TRADES)).toBe(5));
+});
+
+describe('winningTrades / losingTrades', () => {
+  it('counts wins (pnlPercent > 0)', () => expect(winningTrades(SAMPLE_TRADES)).toBe(3));
+  it('counts losses (pnlPercent < 0)', () => expect(losingTrades(SAMPLE_TRADES)).toBe(2));
+  it('breakeven trade is neither win nor loss', () => {
+    const trades = [WIN, BREAKEVEN, LOSS];
+    expect(winningTrades(trades)).toBe(1);
+    expect(losingTrades(trades)).toBe(1);
+  });
+});
+
+describe('winRate', () => {
+  it('returns 60 for 3 wins out of 5', () => expect(winRate(SAMPLE_TRADES)).toBe(60));
+  it('returns 0 for empty', () => expect(winRate([])).toBe(0));
+});
+
+describe('totalPnLPercent', () => {
+  it('computes total dollar P&L as % of initialBalance', () => {
+    // 30 - 10 + 20 - 20 + 50 = 70 on 1000 = 7%
+    expect(totalPnLPercent(SAMPLE_TRADES, 1000)).toBeCloseTo(7, 5);
+  });
+
+  it('returns 0 for zero initialBalance', () => {
+    expect(totalPnLPercent(SAMPLE_TRADES, 0)).toBe(0);
+  });
+});
+
+describe('maxDrawdown', () => {
+  it('returns 0 when balance never falls below peak', () => {
+    const increasing = [makeTrade(1, 10), makeTrade(2, 20), makeTrade(3, 30)];
+    expect(maxDrawdown(increasing, 1000)).toBe(0);
+  });
+
+  it('computes correct drawdown for a known sequence', () => {
+    // 1000 → +100 → 1100 (peak) → -200 → 900 → drawdown = (900-1100)/1100 * 100 ≈ -18.18%
+    const trades = [makeTrade(10, 100), makeTrade(-20, -200)];
+    const dd = maxDrawdown(trades, 1000);
+    expect(dd).toBeCloseTo(-18.18, 1);
+  });
+});
+
+describe('profitFactor', () => {
+  it('computes gross profit / gross loss', () => {
+    // gross profit: 30+20+50=100, gross loss: 10+20=30 → pf = 100/30 ≈ 3.33
+    expect(profitFactor(SAMPLE_TRADES)).toBeCloseTo(100 / 30, 5);
+  });
+});
+
+describe('expectedValue', () => {
+  it('returns average pnlPercent', () => {
+    // (3 - 1 + 2 - 2 + 5) / 5 = 7/5 = 1.4
+    expect(expectedValue(SAMPLE_TRADES)).toBeCloseTo(1.4, 5);
+  });
+});
+
+describe('averageWin / averageLoss', () => {
+  it('averageWin averages positive pnlPercent', () => {
+    // (3+2+5)/3 = 10/3 ≈ 3.33
+    expect(averageWin(SAMPLE_TRADES)).toBeCloseTo(10 / 3, 5);
+  });
+
+  it('averageLoss averages negative pnlPercent', () => {
+    // (-1-2)/2 = -1.5
+    expect(averageLoss(SAMPLE_TRADES)).toBeCloseTo(-1.5, 5);
+  });
+});
+
+describe('largestWin / largestLoss', () => {
+  it('largestWin returns maximum positive pnlPercent', () => {
+    expect(largestWin(SAMPLE_TRADES)).toBe(5);
+  });
+
+  it('largestLoss returns minimum (most negative) pnlPercent', () => {
+    expect(largestLoss(SAMPLE_TRADES)).toBe(-2);
+  });
+});
+
+describe('averageHoldTime', () => {
+  it('returns 1 hour for 1-hour trades', () => {
+    const trades = [WIN, LOSS]; // both use 1h hold time
+    expect(averageHoldTime(trades)).toBeCloseTo(1, 5);
+  });
+
+  it('handles mixed hold times', () => {
+    const t1 = makeTrade(1, 10, {
+      entryTimestamp: new Date('2026-01-01T00:00:00Z'),
+      exitTimestamp: new Date('2026-01-01T02:00:00Z'), // 2 hours
+    });
+    const t2 = makeTrade(-1, -10, {
+      entryTimestamp: new Date('2026-01-01T00:00:00Z'),
+      exitTimestamp: new Date('2026-01-01T04:00:00Z'), // 4 hours
+    });
+    expect(averageHoldTime([t1, t2])).toBeCloseTo(3, 5);
+  });
+});
+
+describe('buildEquityCurve', () => {
+  it('starts with initialBalance and appends one point per trade', () => {
+    const curve = buildEquityCurve(SAMPLE_TRADES, 1000);
+    // 1 initial + 5 trades = 6 points
+    expect(curve).toHaveLength(6);
+    expect(curve[0].balance).toBe(1000);
+  });
+
+  it('correctly tracks running balance', () => {
+    const trades = [makeTrade(10, 100), makeTrade(-5, -50)];
+    const curve = buildEquityCurve(trades, 1000);
+    expect(curve[1].balance).toBe(1100);
+    expect(curve[2].balance).toBe(1050);
+  });
+
+  it('returns single-element array for empty trades', () => {
+    const curve = buildEquityCurve([], 1000);
+    expect(curve).toHaveLength(1);
+    expect(curve[0].balance).toBe(1000);
+  });
+});
+
+describe('sharpeRatio', () => {
+  it('returns 0 for fewer than 2 trades', () => {
+    expect(sharpeRatio([])).toBe(0);
+    expect(sharpeRatio([WIN])).toBe(0);
+  });
+
+  it('returns 0 when all returns are identical (zero std dev)', () => {
+    const identical = [makeTrade(2, 20), makeTrade(2, 20), makeTrade(2, 20)];
+    expect(sharpeRatio(identical)).toBe(0);
+  });
+
+  it('returns positive value for overall positive returns', () => {
+    const trades = [makeTrade(3, 30), makeTrade(2, 20), makeTrade(4, 40)];
+    expect(sharpeRatio(trades)).toBeGreaterThan(0);
+  });
+});
+
+describe('calculateMetrics — aggregate', () => {
+  it('returns correct totalTrades', () => {
+    const m = calculateMetrics(SAMPLE_TRADES, 1000);
+    expect(m.totalTrades).toBe(5);
+  });
+
+  it('returns correct winRate', () => {
+    const m = calculateMetrics(SAMPLE_TRADES, 1000);
+    expect(m.winRate).toBe(60);
+  });
+
+  it('equityCurve has correct length', () => {
+    const m = calculateMetrics(SAMPLE_TRADES, 1000);
+    expect(m.equityCurve).toHaveLength(6);
+  });
+
+  it('handles empty trade array gracefully', () => {
+    const m = calculateMetrics([], 1000);
+    expect(m.totalTrades).toBe(0);
+    expect(m.winRate).toBe(0);
+    expect(m.maxDrawdown).toBe(0);
+    expect(m.profitFactor).toBe(0);
+    expect(m.equityCurve).toHaveLength(1);
+  });
+});

--- a/apps/trading-simulator/tests/shared-metrics.test.ts
+++ b/apps/trading-simulator/tests/shared-metrics.test.ts
@@ -213,9 +213,16 @@ describe('buildEquityCurve', () => {
   });
 
   it('returns single-element array for empty trades', () => {
-    const curve = buildEquityCurve([], 1000);
+    const start = new Date('2026-01-01T00:00:00Z');
+    const curve = buildEquityCurve([], 1000, start);
     expect(curve).toHaveLength(1);
     expect(curve[0].balance).toBe(1000);
+    expect(curve[0].timestamp).toEqual(start);
+  });
+
+  it('empty trades with no startTimestamp defaults to epoch (new Date(0))', () => {
+    const curve = buildEquityCurve([], 1000);
+    expect(curve[0].timestamp).toEqual(new Date(0));
   });
 });
 
@@ -233,6 +240,13 @@ describe('sharpeRatio', () => {
   it('returns positive value for overall positive returns', () => {
     const trades = [makeTrade(3, 30), makeTrade(2, 20), makeTrade(4, 40)];
     expect(sharpeRatio(trades)).toBeGreaterThan(0);
+  });
+
+  it('non-zero riskFreeReturnPercent lowers the ratio', () => {
+    const trades = [makeTrade(3, 30), makeTrade(2, 20), makeTrade(4, 40)];
+    const withoutRfr = sharpeRatio(trades, 0);
+    const withRfr = sharpeRatio(trades, 1); // 1% per-trade risk-free return
+    expect(withRfr).toBeLessThan(withoutRfr);
   });
 });
 

--- a/apps/trading-simulator/tests/shared-metrics.test.ts
+++ b/apps/trading-simulator/tests/shared-metrics.test.ts
@@ -143,9 +143,9 @@ describe('maxDrawdown', () => {
 });
 
 describe('profitFactor', () => {
-  it('computes gross profit / gross loss', () => {
-    // gross profit: 30+20+50=100, gross loss: 10+20=30 → pf = 100/30 ≈ 3.33
-    expect(profitFactor(SAMPLE_TRADES)).toBeCloseTo(100 / 30, 5);
+  it('computes gross profit / gross loss using pnlPercent', () => {
+    // gross profit (percent): 3+2+5=10, gross loss (percent): 1+2=3 → pf = 10/3 ≈ 3.33
+    expect(profitFactor(SAMPLE_TRADES)).toBeCloseTo(10 / 3, 5);
   });
 });
 

--- a/apps/trading-simulator/tests/shared-pattern-display.test.ts
+++ b/apps/trading-simulator/tests/shared-pattern-display.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CANDLE_WIDTH,
+  formatPattern,
+  render3CandleWindow,
+  renderCandle,
+} from '../src/shared/pattern-display.js';
+import type { OhlcCandle } from '../src/engine/types.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeCandle(
+  open: number,
+  high: number,
+  low: number,
+  close: number,
+): OhlcCandle {
+  const range = high - low;
+  return {
+    open_time: 0,
+    open,
+    high,
+    low,
+    close,
+    volume: 0,
+    quote_volume: 0,
+    num_trades: 0,
+    pct_change: ((close - open) / open) * 100,
+    body_ratio: range === 0 ? 0 : Math.abs(close - open) / range,
+    candle_range: range === 0 ? 0 : (range / open) * 100,
+  };
+}
+
+const BULLISH = makeCandle(100, 110, 95, 108); // close > open
+const BEARISH = makeCandle(100, 108, 95, 97);  // close < open
+const DOJI = makeCandle(100, 105, 95, 100);    // close === open
+
+// ── renderCandle ──────────────────────────────────────────────────────────────
+
+describe('renderCandle — output shape', () => {
+  it('returns exactly `height` lines', () => {
+    const lines = renderCandle(BULLISH, 10);
+    expect(lines).toHaveLength(10);
+  });
+
+  it('every line is CANDLE_WIDTH characters wide', () => {
+    const lines = renderCandle(BEARISH, 8);
+    for (const line of lines) {
+      expect(line).toHaveLength(CANDLE_WIDTH);
+    }
+  });
+
+  it('works for height of 1', () => {
+    const lines = renderCandle(BULLISH, 1);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toHaveLength(CANDLE_WIDTH);
+  });
+});
+
+describe('renderCandle — bullish vs bearish body', () => {
+  it('bullish candle body row contains █', () => {
+    const lines = renderCandle(BULLISH, 20);
+    const bodyLines = lines.filter((l) => l.includes('█'));
+    expect(bodyLines.length).toBeGreaterThan(0);
+  });
+
+  it('bearish candle body row uses outlined style (│ at edges)', () => {
+    const lines = renderCandle(BEARISH, 20);
+    const bodyLines = lines.filter((l) => l.startsWith('│') && l.endsWith('│'));
+    expect(bodyLines.length).toBeGreaterThan(0);
+  });
+
+  it('bullish candle has no outlined body rows', () => {
+    const lines = renderCandle(BULLISH, 20);
+    const outlinedRows = lines.filter((l) => l.startsWith('│') && l.endsWith('│'));
+    expect(outlinedRows).toHaveLength(0);
+  });
+});
+
+describe('renderCandle — wick rows', () => {
+  it('wick rows contain ││', () => {
+    const lines = renderCandle(BULLISH, 20);
+    const wickRows = lines.filter((l) => l.includes('││'));
+    expect(wickRows.length).toBeGreaterThan(0);
+  });
+
+  it('doji candle still renders without error', () => {
+    const lines = renderCandle(DOJI, 10);
+    expect(lines).toHaveLength(10);
+    for (const line of lines) {
+      expect(line).toHaveLength(CANDLE_WIDTH);
+    }
+  });
+});
+
+describe('renderCandle — flat candle (high === low)', () => {
+  it('renders without throwing for zero-range candle', () => {
+    const flat = makeCandle(100, 100, 100, 100);
+    expect(() => renderCandle(flat, 10)).not.toThrow();
+    const lines = renderCandle(flat, 10);
+    expect(lines).toHaveLength(10);
+  });
+});
+
+// ── render3CandleWindow ───────────────────────────────────────────────────────
+
+describe('render3CandleWindow — output shape', () => {
+  const c1 = makeCandle(100, 110, 95, 108);
+  const c2 = makeCandle(108, 115, 106, 112);
+  const c3 = makeCandle(112, 120, 110, 118);
+
+  it('returns exactly `height` lines', () => {
+    const lines = render3CandleWindow([c1, c2, c3], 12);
+    expect(lines).toHaveLength(12);
+  });
+
+  it('each line has the expected width (3 candles + 2 gaps)', () => {
+    const lines = render3CandleWindow([c1, c2, c3], 12);
+    const expectedWidth = CANDLE_WIDTH * 3 + 2 * 2; // 3 candles + 2 × 2-char gap
+    for (const line of lines) {
+      expect(line).toHaveLength(expectedWidth);
+    }
+  });
+});
+
+describe('render3CandleWindow — shared price range', () => {
+  it('candles are normalized against global high/low', () => {
+    // All candles with very different ranges — should still render consistently
+    const low = makeCandle(100, 102, 99, 101);
+    const mid = makeCandle(150, 155, 148, 153);
+    const high = makeCandle(200, 210, 198, 205);
+    expect(() => render3CandleWindow([low, mid, high], 10)).not.toThrow();
+    const lines = render3CandleWindow([low, mid, high], 10);
+    expect(lines).toHaveLength(10);
+  });
+});
+
+// ── formatPattern ─────────────────────────────────────────────────────────────
+
+describe('formatPattern', () => {
+  it('formats three labels into bracketed, comma-separated string', () => {
+    expect(formatPattern(['up_weak', 'up_weak', 'up_medium'])).toBe(
+      '[up_weak, up_weak, up_medium]',
+    );
+  });
+
+  it('formats all-strong pattern', () => {
+    expect(formatPattern(['up_strong', 'up_strong', 'up_strong'])).toBe(
+      '[up_strong, up_strong, up_strong]',
+    );
+  });
+
+  it('formats mixed direction pattern', () => {
+    expect(formatPattern(['down_medium', 'up_weak', 'down_strong'])).toBe(
+      '[down_medium, up_weak, down_strong]',
+    );
+  });
+});

--- a/apps/trading-simulator/tests/shared-pattern-display.test.ts
+++ b/apps/trading-simulator/tests/shared-pattern-display.test.ts
@@ -133,6 +133,17 @@ describe('render3CandleWindow — shared price range', () => {
     const lines = render3CandleWindow([low, mid, high], 10);
     expect(lines).toHaveLength(10);
   });
+
+  it('all three candles flat (globalHigh === globalLow) renders without throwing', () => {
+    const flat = makeCandle(100, 100, 100, 100);
+    expect(() => render3CandleWindow([flat, flat, flat], 10)).not.toThrow();
+    const lines = render3CandleWindow([flat, flat, flat], 10);
+    expect(lines).toHaveLength(10);
+    const expectedWidth = CANDLE_WIDTH * 3 + 2 * 2;
+    for (const line of lines) {
+      expect(line).toHaveLength(expectedWidth);
+    }
+  });
 });
 
 // ── formatPattern ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
Implements the three shared utility modules described in issue #52:

- `src/shared/execution-log.ts` — in-memory trade audit log with JSON/CSV export
- `src/shared/metrics.ts` — pure performance metrics calculator (Sharpe, drawdown, equity curve, etc)
- `src/shared/pattern-display.ts` — ASCII candle renderer for TUI
- `src/shared/types.ts` — minimal shared types

Also adds unit tests for all three modules.

Closes #52

Generated with [Claude Code](https://claude.ai/code)