### PR TITLE
Add terminal user interface for backtest simulator using ink

### DIFF
--- a/apps/trading-simulator/package.json
+++ b/apps/trading-simulator/package.json
@@ -7,6 +7,8 @@
   "scripts": {
     "start": "tsx --env-file .env src/index.ts",
     "dev": "tsx --env-file .env --watch src/index.ts",
+    "tui": "tsx --env-file .env src/tui.tsx",
+    "tui:dummy": "tsx --env-file .env src/tui.tsx --strategy=dummy",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
@@ -14,12 +16,16 @@
   "dependencies": {
     "@crypto-terminal/trade-formula": "workspace:*",
     "drizzle-orm": "^0.40.0",
+    "ink": "^5.0.1",
+    "ink-spinner": "^5.0.0",
     "pg": "^8.13.3",
-    "pino": "^9.0.0"
+    "pino": "^9.0.0",
+    "react": "^18.3.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/pg": "^8.11.0",
+    "@types/react": "^18.3.0",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"

--- a/apps/trading-simulator/src/strategies/loader.ts
+++ b/apps/trading-simulator/src/strategies/loader.ts
@@ -7,7 +7,7 @@ import { PatternBasedV1 } from './pattern-based-v1/index.js';
 
 // ── Strategy registry ─────────────────────────────────────────────────────────
 
-const KNOWN_STRATEGIES = ['pattern-based-v1'] as const;
+export const KNOWN_STRATEGIES = ['pattern-based-v1'] as const;
 export type StrategyName = (typeof KNOWN_STRATEGIES)[number];
 
 /**

--- a/apps/trading-simulator/src/tui.tsx
+++ b/apps/trading-simulator/src/tui.tsx
@@ -15,7 +15,7 @@ import { render } from 'ink';
 import { config } from './config.js';
 import { createDb } from './db/client.js';
 import { fetchAllCandles } from './db/queries.js';
-import { loadStrategy } from './strategies/loader.js';
+import { loadStrategy, KNOWN_STRATEGIES } from './strategies/loader.js';
 import { BASE_STRATEGY_CONFIG } from './strategies/base-config.js';
 import type { OhlcCandle, StrategyRunner, TradeSignal, ExecutedTrade } from './engine/types.js';
 import { App } from './tui/App.js';
@@ -26,6 +26,14 @@ const { Pool } = pg;
 
 const args = process.argv.slice(2);
 const strategyArg = args.find((a) => a.startsWith('--strategy='))?.split('=')[1] ?? 'dummy';
+
+const VALID_STRATEGIES = ['dummy', ...KNOWN_STRATEGIES] as const;
+if (!VALID_STRATEGIES.includes(strategyArg as (typeof VALID_STRATEGIES)[number])) {
+  process.stderr.write(
+    `[tui] Unknown strategy: "${strategyArg}". Valid strategies: ${VALID_STRATEGIES.join(', ')}\n`,
+  );
+  process.exit(1);
+}
 
 // ── Dummy strategy (no-op) ────────────────────────────────────────────────────
 

--- a/apps/trading-simulator/src/tui.tsx
+++ b/apps/trading-simulator/src/tui.tsx
@@ -25,7 +25,7 @@ const { Pool } = pg;
 // ── Parse CLI args ────────────────────────────────────────────────────────────
 
 const args = process.argv.slice(2);
-const strategyArg = args.find((a) => a.startsWith('--strategy='))?.split('=')[1] ?? 'dummy';
+const strategyArg = args.find((a) => a.startsWith('--strategy='))?.split('=')[1] || 'dummy';
 
 const VALID_STRATEGIES = ['dummy', ...KNOWN_STRATEGIES] as const;
 if (!VALID_STRATEGIES.includes(strategyArg as (typeof VALID_STRATEGIES)[number])) {

--- a/apps/trading-simulator/src/tui.tsx
+++ b/apps/trading-simulator/src/tui.tsx
@@ -1,0 +1,110 @@
+/**
+ * TUI entry point for the backtest simulator.
+ *
+ * Usage:
+ *   tsx --env-file .env src/tui.tsx [--strategy=pattern-based-v1]
+ *
+ * Environment variables (same as index.ts):
+ *   DATABASE_URL      – PostgreSQL connection string
+ *   INSTRUMENT        – e.g. BTCUSDT (default)
+ *   TIMEFRAME         – e.g. 5m (default)
+ *   INITIAL_BALANCE   – starting USD balance (default 1000)
+ */
+import pg from 'pg';
+import { render } from 'ink';
+import { config } from './config.js';
+import { createDb } from './db/client.js';
+import { fetchAllCandles } from './db/queries.js';
+import { loadStrategy } from './strategies/loader.js';
+import { BASE_STRATEGY_CONFIG } from './strategies/base-config.js';
+import type { OhlcCandle, StrategyRunner, TradeSignal, ExecutedTrade } from './engine/types.js';
+import { App } from './tui/App.js';
+
+const { Pool } = pg;
+
+// ── Parse CLI args ────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+const strategyArg = args.find((a) => a.startsWith('--strategy='))?.split('=')[1] ?? 'dummy';
+
+// ── Dummy strategy (no-op) ────────────────────────────────────────────────────
+
+const dummyStrategy: StrategyRunner = {
+  name: 'dummy',
+  version: '0.0.1',
+  analyze(_candles: [OhlcCandle, OhlcCandle, OhlcCandle]): TradeSignal | null {
+    return null;
+  },
+  onTradeExecuted(_trade: ExecutedTrade): void {
+    // no-op
+  },
+};
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+async function main() {
+  process.stdout.write('[tui] Starting backtest TUI…\n');
+
+  const pool = new Pool({ connectionString: config.database.url });
+
+  try {
+    // Verify DB connection
+    const client = await pool.connect();
+    await client.query('SELECT 1');
+    client.release();
+
+    const db = createDb(pool);
+
+    // Load strategy
+    let strategy: StrategyRunner;
+    if (strategyArg === 'dummy') {
+      strategy = dummyStrategy;
+    } else {
+      strategy = await loadStrategy(
+        strategyArg as Parameters<typeof loadStrategy>[0],
+        db,
+        {
+          instrument: config.instrument,
+          timeframe: config.timeframe,
+          initialBalance: config.initialBalance,
+          ...BASE_STRATEGY_CONFIG,
+        },
+      );
+    }
+
+    process.stdout.write(`[tui] Strategy loaded: ${strategy.name} v${strategy.version}\n`);
+
+    // Fetch candles
+    process.stdout.write('[tui] Loading candles…\n');
+    const candles = await fetchAllCandles(db, config.instrument, config.timeframe);
+    process.stdout.write(`[tui] Loaded ${candles.length} candles\n`);
+
+    if (candles.length < 3) {
+      process.stderr.write('[tui] Not enough candles to run (need at least 3)\n');
+      process.exit(1);
+    }
+
+    // Close pool (TUI loop takes over from here — no more DB needed)
+    await pool.end();
+
+    // Render TUI
+    render(
+      <App
+        candles={candles}
+        strategy={strategy}
+        strategyName={strategy.name}
+        instrument={config.instrument}
+        timeframe={config.timeframe}
+        initialBalance={config.initialBalance}
+        riskPercent={BASE_STRATEGY_CONFIG.riskPct}
+        tpMultiplier={BASE_STRATEGY_CONFIG.tpMultiplier}
+      />,
+    );
+  } catch (err) {
+    await pool.end().catch(() => undefined);
+    process.stderr.write(`[tui] Fatal: ${String(err)}\n`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/apps/trading-simulator/src/tui/App.tsx
+++ b/apps/trading-simulator/src/tui/App.tsx
@@ -1,0 +1,91 @@
+import { useApp } from 'ink';
+import { Box } from 'ink';
+import type { TuiAppProps } from './types.js';
+import { useBacktest } from './hooks/useBacktest.js';
+import { useKeyboard } from './hooks/useKeyboard.js';
+import { Header } from './components/Header.js';
+import { Configuration } from './components/Configuration.js';
+import { PerformanceMetrics } from './components/PerformanceMetrics.js';
+import { TradeLog } from './components/TradeLog.js';
+import { PatternDisplay } from './components/PatternDisplay.js';
+import { Footer } from './components/Footer.js';
+
+export function App({
+  candles,
+  strategy,
+  strategyName,
+  instrument,
+  timeframe,
+  initialBalance,
+  riskPercent,
+  tpMultiplier,
+}: TuiAppProps) {
+  const { exit } = useApp();
+
+  const {
+    state,
+    speed,
+    start,
+    pause,
+    resume,
+    restart,
+    saveResults,
+    increaseSpeed,
+    decreaseSpeed,
+  } = useBacktest(candles, strategy, initialBalance);
+
+  useKeyboard({
+    status: state.status,
+    onStart:     start,
+    onPause:     pause,
+    onResume:    resume,
+    onRestart:   restart,
+    onSave:      saveResults,
+    onQuit:      exit,
+    onSpeedUp:   increaseSpeed,
+    onSpeedDown: decreaseSpeed,
+  });
+
+  return (
+    <Box flexDirection="column" height="100%">
+      {/* Header */}
+      <Header
+        strategy={strategyName}
+        instrument={instrument}
+        timeframe={timeframe}
+        status={state.status}
+        progress={state.progress}
+      />
+
+      {/* Main content */}
+      <Box flexDirection="row" flexGrow={1}>
+        {/* Left column: 70% */}
+        <Box flexDirection="column" width="70%">
+          <Configuration
+            initialBalance={initialBalance}
+            currentBalance={state.currentBalance}
+            riskPercent={riskPercent}
+            tpMultiplier={tpMultiplier}
+            currentTimestamp={state.currentTimestamp}
+            candlesProcessed={state.candlesProcessed}
+            totalCandles={state.totalCandles}
+          />
+          <PerformanceMetrics metrics={state.metrics} />
+          <TradeLog trades={state.trades} />
+        </Box>
+
+        {/* Right column: 30% */}
+        <Box width="30%">
+          <PatternDisplay
+            candles={state.currentCandles}
+            patternData={state.patternData}
+            tradeSignal={state.tradeSignal}
+          />
+        </Box>
+      </Box>
+
+      {/* Footer */}
+      <Footer status={state.status} speed={speed} />
+    </Box>
+  );
+}

--- a/apps/trading-simulator/src/tui/components/Configuration.tsx
+++ b/apps/trading-simulator/src/tui/components/Configuration.tsx
@@ -1,0 +1,64 @@
+import { Box, Text } from 'ink';
+import { formatCurrency, formatPercent, formatTimestamp } from '../utils/formatting.js';
+
+interface ConfigurationProps {
+  initialBalance: number;
+  currentBalance: number;
+  riskPercent: number;
+  tpMultiplier: number;
+  currentTimestamp: Date;
+  candlesProcessed: number;
+  totalCandles: number;
+}
+
+function Row({ label, value, valueColor }: { label: string; value: string; valueColor?: string }) {
+  return (
+    <Box justifyContent="space-between" paddingX={1}>
+      <Text color="gray">{label}</Text>
+      <Text color={valueColor ?? 'white'}>{value}</Text>
+    </Box>
+  );
+}
+
+export function Configuration({
+  initialBalance,
+  currentBalance,
+  riskPercent,
+  tpMultiplier,
+  currentTimestamp,
+  candlesProcessed,
+  totalCandles,
+}: ConfigurationProps) {
+  const balanceDiff = currentBalance - initialBalance;
+  const balanceColor = balanceDiff >= 0 ? 'green' : 'red';
+  const timestampValid = currentTimestamp.getTime() > 0;
+
+  return (
+    <Box
+      borderStyle="single"
+      borderColor="gray"
+      flexDirection="column"
+      paddingY={0}
+    >
+      <Box paddingX={1}>
+        <Text bold color="white"> CONFIGURATION</Text>
+      </Box>
+      <Row label="Initial Balance" value={formatCurrency(initialBalance)} />
+      <Row
+        label="Current Balance"
+        value={formatCurrency(currentBalance)}
+        valueColor={balanceColor}
+      />
+      <Row label="Risk / Trade" value={formatPercent(riskPercent)} />
+      <Row label="TP Multiplier" value={`${tpMultiplier}x`} />
+      <Row
+        label="Current Time"
+        value={timestampValid ? formatTimestamp(currentTimestamp) : '—'}
+      />
+      <Row
+        label="Candles"
+        value={`${candlesProcessed.toLocaleString()} / ${totalCandles.toLocaleString()}`}
+      />
+    </Box>
+  );
+}

--- a/apps/trading-simulator/src/tui/components/Footer.tsx
+++ b/apps/trading-simulator/src/tui/components/Footer.tsx
@@ -1,0 +1,34 @@
+import { Box, Text } from 'ink';
+import type { BacktestStatus } from '../types.js';
+import { formatSpeed } from '../utils/formatting.js';
+
+interface FooterProps {
+  status: BacktestStatus;
+  speed: number;
+}
+
+export function Footer({ status, speed }: FooterProps) {
+  const spaceLabel =
+    status === 'IDLE'    ? '[SPACE] Start'   :
+    status === 'RUNNING' ? '[SPACE] Pause'   :
+    status === 'PAUSED'  ? '[SPACE] Resume'  :
+                           '[SPACE] —';
+
+  return (
+    <Box
+      borderStyle="single"
+      borderColor="gray"
+      paddingX={1}
+      justifyContent="space-between"
+    >
+      <Box gap={3}>
+        <Text color="cyan">{spaceLabel}</Text>
+        <Text color="cyan">[R] Restart</Text>
+        <Text color="cyan">[S] Save Results</Text>
+        <Text color="cyan">[Q] Quit</Text>
+        <Text color="cyan">[↑/↓] Speed</Text>
+      </Box>
+      <Text color="yellow">Speed: <Text bold>{formatSpeed(speed)}</Text></Text>
+    </Box>
+  );
+}

--- a/apps/trading-simulator/src/tui/components/Header.tsx
+++ b/apps/trading-simulator/src/tui/components/Header.tsx
@@ -1,0 +1,58 @@
+import { Box, Text } from 'ink';
+import type { BacktestStatus } from '../types.js';
+
+interface HeaderProps {
+  strategy: string;
+  instrument: string;
+  timeframe: string;
+  status: BacktestStatus;
+  progress: number;
+}
+
+const STATUS_COLORS: Record<BacktestStatus, string> = {
+  IDLE:     'gray',
+  RUNNING:  'green',
+  PAUSED:   'yellow',
+  COMPLETE: 'cyan',
+};
+
+const STATUS_LABELS: Record<BacktestStatus, string> = {
+  IDLE:     '○ IDLE',
+  RUNNING:  '● RUNNING',
+  PAUSED:   '⏸ PAUSED',
+  COMPLETE: '✓ COMPLETE',
+};
+
+export function Header({ strategy, instrument, timeframe, status, progress }: HeaderProps) {
+  const color = STATUS_COLORS[status];
+  const label = STATUS_LABELS[status];
+  const progressStr =
+    status === 'RUNNING' || status === 'PAUSED' || status === 'COMPLETE'
+      ? ` (${progress.toFixed(1)}% complete)`
+      : '';
+
+  return (
+    <Box
+      borderStyle="double"
+      borderColor="cyan"
+      paddingX={1}
+      justifyContent="space-between"
+    >
+      <Text bold color="cyan">
+        PHANTOM TERMINAL — BACKTEST SIMULATOR
+      </Text>
+      <Box gap={3}>
+        <Text color="white">
+          Strategy: <Text bold>{strategy}</Text>
+        </Text>
+        <Text color="white">
+          {instrument} {timeframe}
+        </Text>
+        <Text color={color}>
+          {label}
+          {progressStr}
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/apps/trading-simulator/src/tui/components/PatternDisplay.tsx
+++ b/apps/trading-simulator/src/tui/components/PatternDisplay.tsx
@@ -1,0 +1,160 @@
+import type { ReactNode } from 'react';
+import { Box, Text } from 'ink';
+import { render3CandleWindow, formatPattern } from '../../shared/pattern-display.js';
+import type { OhlcCandle, TradeSignal } from '../../engine/types.js';
+import type { PatternAnalysisData } from '../types.js';
+import { formatCurrency, formatPercent, formatNumber } from '../utils/formatting.js';
+
+interface PatternDisplayProps {
+  candles: [OhlcCandle, OhlcCandle, OhlcCandle] | null;
+  patternData: PatternAnalysisData | null;
+  tradeSignal: TradeSignal | null;
+}
+
+const CANDLE_RENDER_HEIGHT = 8;
+
+function Section({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      <Text bold color="yellow">{title}</Text>
+      {children}
+    </Box>
+  );
+}
+
+function KV({ label, value, valueColor }: { label: string; value: string; valueColor?: string }) {
+  return (
+    <Box>
+      <Text color="gray">{label}: </Text>
+      <Text color={valueColor ?? 'white'}>{value}</Text>
+    </Box>
+  );
+}
+
+export function PatternDisplay({ candles, patternData, tradeSignal }: PatternDisplayProps) {
+  return (
+    <Box
+      borderStyle="single"
+      borderColor="gray"
+      flexDirection="column"
+      paddingX={1}
+      width="100%"
+    >
+      <Text bold color="white"> PATTERN DISPLAY</Text>
+
+      {/* 3-Candle window */}
+      <Section title="─ 3-CANDLE WINDOW">
+        {candles ? (
+          <Box flexDirection="column">
+            {render3CandleWindow(candles, CANDLE_RENDER_HEIGHT).map((line, i) => (
+              <Text key={i} color="white">{line}</Text>
+            ))}
+            <Box gap={2} marginTop={0}>
+              <Text color="gray"> C1</Text>
+              <Text color="gray">    C2</Text>
+              <Text color="gray">    C3</Text>
+            </Box>
+          </Box>
+        ) : (
+          <Text color="gray">Waiting for candles…</Text>
+        )}
+      </Section>
+
+      {/* Pattern classification */}
+      {patternData ? (
+        <Section title="─ CLASSIFICATION">
+          <KV label="C1" value={patternData.c1Label} />
+          <KV label="C2" value={patternData.c2Label} />
+          <KV label="C3" value={patternData.c3Label} />
+          <KV
+            label="Pattern"
+            value={formatPattern([patternData.c1Label, patternData.c2Label, patternData.c3Label])}
+          />
+          {patternData.upProbability !== undefined && (
+            <KV
+              label="Postgres"
+              value={`${patternData.upProbability.toFixed(0)}% UP / ${patternData.downProbability?.toFixed(0) ?? '?'}% DOWN`}
+            />
+          )}
+        </Section>
+      ) : (
+        <Section title="─ CLASSIFICATION">
+          <Text color="gray">—</Text>
+        </Section>
+      )}
+
+      {/* Pre-computation values */}
+      {patternData?.momentumScores ? (
+        <Section title="─ PRE-COMPUTE">
+          <Box>
+            <Text color="gray">Momentum: </Text>
+            <Text>
+              C1:{formatNumber(patternData.momentumScores[0])}  C2:{formatNumber(patternData.momentumScores[1])}  C3:{formatNumber(patternData.momentumScores[2])}
+            </Text>
+          </Box>
+          {patternData.sequenceSlope !== undefined && (
+            <KV
+              label="Seq Slope"
+              value={formatNumber(patternData.sequenceSlope)}
+              valueColor={patternData.sequenceSlope >= 0 ? 'green' : 'red'}
+            />
+          )}
+          {patternData.volatilityProxy !== undefined && (
+            <KV label="Volatility" value={`${formatNumber(patternData.volatilityProxy)}%`} />
+          )}
+          {patternData.directionalAgreement !== undefined && (
+            <KV
+              label="Dir Agree"
+              value={String(patternData.directionalAgreement)}
+              valueColor={patternData.directionalAgreement > 0 ? 'green' : patternData.directionalAgreement < 0 ? 'red' : 'white'}
+            />
+          )}
+          {patternData.wickRatios && (
+            <Box>
+              <Text color="gray">Wick: </Text>
+              <Text>
+                C1:{formatNumber(patternData.wickRatios[0])}  C2:{formatNumber(patternData.wickRatios[1])}  C3:{formatNumber(patternData.wickRatios[2])}
+              </Text>
+            </Box>
+          )}
+          {patternData.route && (
+            <KV label="Route" value={patternData.route} valueColor="cyan" />
+          )}
+          {patternData.conviction && (
+            <KV label="Conviction" value={patternData.conviction} valueColor="yellow" />
+          )}
+        </Section>
+      ) : null}
+
+      {/* Trade decision */}
+      {tradeSignal ? (
+        <Section title="─ TRADE SIGNAL">
+          <KV
+            label="Direction"
+            value={tradeSignal.direction}
+            valueColor={tradeSignal.direction === 'LONG' ? 'green' : 'red'}
+          />
+          {patternData?.route && (
+            <KV label="Route" value={patternData.route!} valueColor="cyan" />
+          )}
+          {patternData?.conviction && (
+            <KV
+              label="Conviction"
+              value={`${patternData.conviction} (${patternData.upProbability ?? patternData.downProbability ?? '?'}%)`}
+              valueColor="yellow"
+            />
+          )}
+          <KV label="Entry" value={formatCurrency(tradeSignal.entryPrice)} />
+          <KV label="Stop Loss" value={formatCurrency(tradeSignal.slPrice)} valueColor="red" />
+          <KV label="Take Profit" value={formatCurrency(tradeSignal.tpPrice)} valueColor="green" />
+          <KV label="Leverage" value={`${tradeSignal.leverage}x`} valueColor="yellow" />
+          <KV label="Dollar Risk" value={formatCurrency(tradeSignal.dollarRisk)} />
+        </Section>
+      ) : (
+        <Section title="─ TRADE SIGNAL">
+          <Text color="gray">No signal this candle</Text>
+        </Section>
+      )}
+    </Box>
+  );
+}

--- a/apps/trading-simulator/src/tui/components/PatternDisplay.tsx
+++ b/apps/trading-simulator/src/tui/components/PatternDisplay.tsx
@@ -72,7 +72,7 @@ export function PatternDisplay({ candles, patternData, tradeSignal }: PatternDis
           />
           {patternData.upProbability !== undefined && (
             <KV
-              label="Postgres"
+              label="Probability"
               value={`${patternData.upProbability.toFixed(0)}% UP / ${patternData.downProbability?.toFixed(0) ?? '?'}% DOWN`}
             />
           )}

--- a/apps/trading-simulator/src/tui/components/PatternDisplay.tsx
+++ b/apps/trading-simulator/src/tui/components/PatternDisplay.tsx
@@ -135,7 +135,7 @@ export function PatternDisplay({ candles, patternData, tradeSignal }: PatternDis
             valueColor={tradeSignal.direction === 'LONG' ? 'green' : 'red'}
           />
           {patternData?.route && (
-            <KV label="Route" value={patternData.route!} valueColor="cyan" />
+            <KV label="Route" value={patternData.route} valueColor="cyan" />
           )}
           {patternData?.conviction && (
             <KV

--- a/apps/trading-simulator/src/tui/components/PerformanceMetrics.tsx
+++ b/apps/trading-simulator/src/tui/components/PerformanceMetrics.tsx
@@ -39,7 +39,9 @@ export function PerformanceMetrics({ metrics }: PerformanceMetricsProps) {
   const curveHeight = 5;
   const curveLines = renderEquityCurve(equityValues, curveWidth, curveHeight);
   const profitFactorStr =
-    metrics.profitFactor === Infinity ? '∞' : formatNumber(metrics.profitFactor, 2);
+    metrics.profitFactor === Infinity || isNaN(metrics.profitFactor)
+      ? '∞'
+      : formatNumber(metrics.profitFactor, 2);
 
   return (
     <Box borderStyle="single" borderColor="gray" flexDirection="column">

--- a/apps/trading-simulator/src/tui/components/PerformanceMetrics.tsx
+++ b/apps/trading-simulator/src/tui/components/PerformanceMetrics.tsx
@@ -1,0 +1,127 @@
+import type { ReactNode } from 'react';
+import { Box, Text } from 'ink';
+import type { PerformanceMetrics } from '../../shared/metrics.js';
+import { formatPercent, formatNumber, renderEquityCurve } from '../utils/formatting.js';
+
+interface PerformanceMetricsProps {
+  metrics: PerformanceMetrics;
+}
+
+function MetricRow({ label, value, valueColor }: { label: string; value: string; valueColor?: string }) {
+  return (
+    <Box justifyContent="space-between" paddingX={1}>
+      <Text color="gray">{label}</Text>
+      <Text color={valueColor ?? 'white'}>{value}</Text>
+    </Box>
+  );
+}
+
+function SubPanel({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <Box flexDirection="column" flexGrow={1} borderStyle="single" borderColor="gray">
+      <Box paddingX={1}>
+        <Text bold color="yellow"> {title}</Text>
+      </Box>
+      {children}
+    </Box>
+  );
+}
+
+function pnlColor(v: number) {
+  return v > 0 ? 'green' : v < 0 ? 'red' : 'white';
+}
+
+export function PerformanceMetrics({ metrics }: PerformanceMetricsProps) {
+  const equityValues = metrics.equityCurve.map((p) => p.balance);
+
+  // P&L curve: 50 wide, 5 tall
+  const curveWidth = 50;
+  const curveHeight = 5;
+  const curveLines = renderEquityCurve(equityValues, curveWidth, curveHeight);
+  const profitFactorStr =
+    metrics.profitFactor === Infinity ? '∞' : formatNumber(metrics.profitFactor, 2);
+
+  return (
+    <Box borderStyle="single" borderColor="gray" flexDirection="column">
+      <Box paddingX={1}>
+        <Text bold color="white"> PERFORMANCE METRICS</Text>
+      </Box>
+      <Box flexDirection="row" gap={1}>
+        {/* Overall */}
+        <SubPanel title="OVERALL">
+          <MetricRow label="Total Trades" value={String(metrics.totalTrades)} />
+          <MetricRow label="Winning" value={String(metrics.winningTrades)} valueColor="green" />
+          <MetricRow label="Losing" value={String(metrics.losingTrades)} valueColor="red" />
+          <MetricRow
+            label="Win Rate"
+            value={formatPercent(metrics.winRate)}
+            valueColor={pnlColor(metrics.winRate - 50)}
+          />
+          <MetricRow
+            label="Total P&L"
+            value={formatPercent(metrics.totalPnL)}
+            valueColor={pnlColor(metrics.totalPnL)}
+          />
+        </SubPanel>
+
+        {/* Risk metrics */}
+        <SubPanel title="RISK">
+          <MetricRow
+            label="Max Drawdown"
+            value={formatPercent(metrics.maxDrawdown)}
+            valueColor="red"
+          />
+          <MetricRow
+            label="Sharpe Ratio"
+            value={formatNumber(metrics.sharpeRatio, 2)}
+            valueColor={pnlColor(metrics.sharpeRatio)}
+          />
+          <MetricRow label="Profit Factor" value={profitFactorStr} />
+          <MetricRow
+            label="Expected Value"
+            value={formatPercent(metrics.expectedValue)}
+            valueColor={pnlColor(metrics.expectedValue)}
+          />
+        </SubPanel>
+
+        {/* Trade statistics */}
+        <SubPanel title="TRADE STATS">
+          <MetricRow
+            label="Avg Win"
+            value={formatPercent(metrics.averageWin)}
+            valueColor="green"
+          />
+          <MetricRow
+            label="Avg Loss"
+            value={formatPercent(metrics.averageLoss)}
+            valueColor="red"
+          />
+          <MetricRow
+            label="Largest Win"
+            value={formatPercent(metrics.largestWin)}
+            valueColor="green"
+          />
+          <MetricRow
+            label="Largest Loss"
+            value={formatPercent(metrics.largestLoss)}
+            valueColor="red"
+          />
+          <MetricRow
+            label="Avg Hold Time"
+            value={`${formatNumber(metrics.averageHoldTime, 1)}h`}
+          />
+        </SubPanel>
+      </Box>
+
+      {/* P&L Curve */}
+      <Box flexDirection="column" paddingX={1} paddingY={0}>
+        <Text bold color="gray"> P&L CURVE</Text>
+        {curveLines.map((line, i) => (
+          <Text key={i} color={metrics.totalPnL >= 0 ? 'green' : 'red'}>
+            {line}
+          </Text>
+        ))}
+      </Box>
+    </Box>
+  );
+}

--- a/apps/trading-simulator/src/tui/components/PerformanceMetrics.tsx
+++ b/apps/trading-simulator/src/tui/components/PerformanceMetrics.tsx
@@ -38,8 +38,9 @@ export function PerformanceMetrics({ metrics }: PerformanceMetricsProps) {
   const curveWidth = 50;
   const curveHeight = 5;
   const curveLines = renderEquityCurve(equityValues, curveWidth, curveHeight);
-  const profitFactorStr =
-    metrics.profitFactor === Infinity || isNaN(metrics.profitFactor)
+  const profitFactorStr = isNaN(metrics.profitFactor)
+    ? 'N/A'
+    : metrics.profitFactor === Infinity
       ? '∞'
       : formatNumber(metrics.profitFactor, 2);
 

--- a/apps/trading-simulator/src/tui/components/TradeLog.tsx
+++ b/apps/trading-simulator/src/tui/components/TradeLog.tsx
@@ -1,0 +1,102 @@
+import { Box, Text } from 'ink';
+import type { ExecutedTrade } from '../../engine/types.js';
+import { formatCurrency, formatTimestamp } from '../utils/formatting.js';
+
+interface TradeLogProps {
+  trades: ExecutedTrade[];
+}
+
+const COL_WIDTHS = {
+  num:    4,
+  time:   11,
+  type:   6,
+  entry:  12,
+  sl:     12,
+  tp:     12,
+  exit:   12,
+  pnl:    9,
+  result: 6,
+};
+
+function pad(s: string, width: number, right = false): string {
+  if (right) return s.padStart(width);
+  return s.padEnd(width);
+}
+
+function HeaderRow() {
+  return (
+    <Box paddingX={1}>
+      <Text bold color="gray">
+        {pad('#',      COL_WIDTHS.num,    false)}
+        {pad('Time',   COL_WIDTHS.time,   false)}
+        {pad('Type',   COL_WIDTHS.type,   false)}
+        {pad('Entry',  COL_WIDTHS.entry,  true)}
+        {'  '}
+        {pad('SL',     COL_WIDTHS.sl,     true)}
+        {'  '}
+        {pad('TP',     COL_WIDTHS.tp,     true)}
+        {'  '}
+        {pad('Exit',   COL_WIDTHS.exit,   true)}
+        {'  '}
+        {pad('P&L',    COL_WIDTHS.pnl,    true)}
+        {'  '}
+        {'Result'}
+      </Text>
+    </Box>
+  );
+}
+
+function TradeRow({ trade }: { trade: ExecutedTrade }) {
+  const isWin = trade.exitReason === 'TP';
+  const pnlColor = trade.pnlPercent > 0 ? 'green' : trade.pnlPercent < 0 ? 'red' : 'white';
+  const directionColor = trade.direction === 'LONG' ? 'green' : 'red';
+  const pnlStr = (trade.pnlPercent >= 0 ? '+' : '') + trade.pnlPercent.toFixed(2) + '%';
+
+  return (
+    <Box paddingX={1}>
+      <Text>
+        {pad(String(trade.id), COL_WIDTHS.num, false)}
+        {pad(formatTimestamp(trade.entryTimestamp), COL_WIDTHS.time, false)}
+      </Text>
+      <Text color={directionColor}>
+        {pad(trade.direction, COL_WIDTHS.type, false)}
+      </Text>
+      <Text>
+        {pad(formatCurrency(trade.entryPrice), COL_WIDTHS.entry, true)}
+        {'  '}
+        {pad(formatCurrency(trade.slPrice),    COL_WIDTHS.sl,    true)}
+        {'  '}
+        {pad(formatCurrency(trade.tpPrice),    COL_WIDTHS.tp,    true)}
+        {'  '}
+        {pad(formatCurrency(trade.exitPrice),  COL_WIDTHS.exit,  true)}
+        {'  '}
+      </Text>
+      <Text color={pnlColor}>
+        {pad(pnlStr, COL_WIDTHS.pnl, true)}
+      </Text>
+      <Text>{'  '}</Text>
+      <Text color={isWin ? 'green' : 'red'}>
+        {isWin ? '✓ TP' : '✗ SL'}
+      </Text>
+    </Box>
+  );
+}
+
+export function TradeLog({ trades }: TradeLogProps) {
+  return (
+    <Box borderStyle="single" borderColor="gray" flexDirection="column">
+      <Box paddingX={1}>
+        <Text bold color="white"> TRADE LOG</Text>
+        <Text color="gray"> (last {trades.length})</Text>
+      </Box>
+      <HeaderRow />
+      {trades.length === 0 ? (
+        <Box paddingX={1}>
+          <Text color="gray">No trades yet</Text>
+        </Box>
+      ) : (
+        trades.map((trade) => <TradeRow key={trade.id} trade={trade} />)
+      )}
+    </Box>
+  );
+}

--- a/apps/trading-simulator/src/tui/hooks/useBacktest.ts
+++ b/apps/trading-simulator/src/tui/hooks/useBacktest.ts
@@ -1,0 +1,278 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { classifyCandle } from '@crypto-terminal/trade-formula';
+import { writeFileSync } from 'node:fs';
+import type { OhlcCandle, ExecutedTrade, StrategyRunner, TradeSignal } from '../../engine/types.js';
+import { TimeMachine } from '../../engine/time-machine.js';
+import { Portfolio } from '../../engine/portfolio.js';
+import { calculateMetrics } from '../../shared/metrics.js';
+import type { BacktestState, BacktestStatus, PatternAnalysisData, SpeedLevel } from '../types.js';
+
+// ── Speed → { intervalMs, batchSize } ────────────────────────────────────────
+
+interface SpeedConfig {
+  intervalMs: number;
+  batchSize: number;
+}
+
+const SPEED_CONFIG: Record<SpeedLevel, SpeedConfig> = {
+  1:    { intervalMs: 100, batchSize: 1 },
+  10:   { intervalMs: 10,  batchSize: 1 },
+  100:  { intervalMs: 10,  batchSize: 10 },
+  1000: { intervalMs: 10,  batchSize: 100 },
+  0:    { intervalMs: 10,  batchSize: 5000 }, // MAX
+};
+
+export const SPEED_LEVELS: SpeedLevel[] = [1, 10, 100, 1000, 0];
+
+// ── Pattern data extraction ───────────────────────────────────────────────────
+
+function extractPatternData(
+  candles: [OhlcCandle, OhlcCandle, OhlcCandle],
+  signal: TradeSignal | null,
+): PatternAnalysisData {
+  const [c1, c2, c3] = candles;
+  const c1Label = classifyCandle(c1.pct_change, c1.body_ratio);
+  const c2Label = classifyCandle(c2.pct_change, c2.body_ratio);
+  const c3Label = classifyCandle(c3.pct_change, c3.body_ratio);
+
+  const base: PatternAnalysisData = { c1Label, c2Label, c3Label };
+
+  if (signal?.metadata) {
+    const m = signal.metadata;
+    const ms = m['momentum_scores'];
+    const wr = m['wick_ratios'];
+    return {
+      ...base,
+      upProbability: typeof m['up_probability'] === 'number' ? m['up_probability'] : undefined,
+      downProbability: typeof m['down_probability'] === 'number' ? m['down_probability'] : undefined,
+      momentumScores:
+        Array.isArray(ms) && ms.length === 3
+          ? (ms as [number, number, number])
+          : undefined,
+      sequenceSlope: typeof m['sequence_slope'] === 'number' ? m['sequence_slope'] : undefined,
+      volatilityProxy: typeof m['volatility_proxy'] === 'number' ? m['volatility_proxy'] : undefined,
+      directionalAgreement:
+        typeof m['directional_agreement'] === 'number' ? m['directional_agreement'] : undefined,
+      wickRatios:
+        Array.isArray(wr) && wr.length === 3 ? (wr as [number, number, number]) : undefined,
+      route: typeof m['route'] === 'string' ? m['route'] : undefined,
+      conviction: typeof m['conviction'] === 'string' ? m['conviction'] : undefined,
+    };
+  }
+
+  return base;
+}
+
+// ── Initial state ─────────────────────────────────────────────────────────────
+
+function buildInitialState(candles: OhlcCandle[], initialBalance: number): BacktestState {
+  return {
+    status: 'IDLE',
+    currentCandles: null,
+    patternData: null,
+    tradeSignal: null,
+    currentBalance: initialBalance,
+    candlesProcessed: 0,
+    totalCandles: candles.length,
+    currentTimestamp: new Date(0),
+    progress: 0,
+    trades: [],
+    metrics: calculateMetrics([], initialBalance),
+  };
+}
+
+// ── useBacktest hook ──────────────────────────────────────────────────────────
+
+export function useBacktest(
+  candles: OhlcCandle[],
+  strategy: StrategyRunner,
+  initialBalance: number,
+) {
+  const [state, setState] = useState<BacktestState>(() =>
+    buildInitialState(candles, initialBalance),
+  );
+  const [speed, setSpeedState] = useState<SpeedLevel>(10);
+
+  const timeMachineRef = useRef<TimeMachine | null>(null);
+  const portfolioRef = useRef<Portfolio | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const statusRef = useRef<BacktestStatus>('IDLE');
+  const speedRef = useRef<SpeedLevel>(10);
+
+  // ── Helpers ─────────────────────────────────────────────────────────────────
+
+  const stopInterval = useCallback(() => {
+    if (intervalRef.current !== null) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  // ── Tick: process N candles and update state ─────────────────────────────────
+
+  const tick = useCallback(() => {
+    const tm = timeMachineRef.current;
+    const portfolio = portfolioRef.current;
+    if (!tm || !portfolio || statusRef.current !== 'RUNNING') return;
+
+    const { batchSize } = SPEED_CONFIG[speedRef.current];
+    const prevTradeCount = portfolio.getTrades().length;
+
+    let lastWindow: [OhlcCandle, OhlcCandle, OhlcCandle] | null = null;
+    let lastSignal: TradeSignal | null = null;
+    let done = false;
+
+    for (let i = 0; i < batchSize; i++) {
+      const window = tm.next();
+      if (!window) {
+        done = true;
+        break;
+      }
+
+      const [, , c3] = window;
+
+      // Check open position exit
+      if (portfolio.hasOpenPosition()) {
+        const slHit = portfolio.checkStopLoss(c3);
+        if (!slHit) portfolio.checkTakeProfit(c3);
+      }
+
+      // Analyze for new entry
+      let signal: TradeSignal | null = null;
+      if (!portfolio.hasOpenPosition()) {
+        signal = strategy.analyze(window);
+        if (signal) portfolio.openPosition(signal, c3.open_time);
+      }
+
+      lastWindow = window;
+      lastSignal = signal;
+    }
+
+    // Notify strategy of trades closed during this batch
+    const allTrades = portfolio.getTrades();
+    const newTrades = allTrades.slice(prevTradeCount);
+    for (const trade of newTrades) {
+      strategy.onTradeExecuted(trade);
+    }
+
+    if (done) {
+      statusRef.current = 'COMPLETE';
+      stopInterval();
+    }
+
+    const progressStr = tm.progress();
+    const parts = progressStr.split(' / ');
+    const processed = parseInt((parts[0] ?? '0').replace(/,/g, ''), 10);
+    const total = parseInt((parts[1] ?? '1').replace(/,/g, ''), 10);
+
+    setState({
+      status: done ? 'COMPLETE' : statusRef.current,
+      currentCandles: lastWindow,
+      patternData: lastWindow ? extractPatternData(lastWindow, lastSignal) : null,
+      tradeSignal: lastSignal,
+      currentBalance: portfolio.getBalance(),
+      candlesProcessed: processed,
+      totalCandles: total,
+      currentTimestamp: lastWindow ? new Date(lastWindow[2].open_time) : new Date(0),
+      progress: total > 0 ? (processed / total) * 100 : 0,
+      trades: allTrades.slice(-8),
+      metrics: calculateMetrics(allTrades, initialBalance),
+    });
+  }, [strategy, initialBalance, stopInterval]);
+
+  // ── Start interval at given speed ────────────────────────────────────────────
+
+  const startInterval = useCallback(
+    (s: SpeedLevel) => {
+      stopInterval();
+      const { intervalMs } = SPEED_CONFIG[s];
+      intervalRef.current = setInterval(tick, Math.max(intervalMs, 1));
+    },
+    [stopInterval, tick],
+  );
+
+  // ── Init / reset engine state ────────────────────────────────────────────────
+
+  const initEngine = useCallback(() => {
+    timeMachineRef.current = new TimeMachine(candles);
+    portfolioRef.current = new Portfolio(initialBalance);
+    statusRef.current = 'IDLE';
+  }, [candles, initialBalance]);
+
+  // ── Public controls ──────────────────────────────────────────────────────────
+
+  const start = useCallback(() => {
+    if (statusRef.current !== 'IDLE') return;
+    statusRef.current = 'RUNNING';
+    setState((prev) => ({ ...prev, status: 'RUNNING' }));
+    startInterval(speedRef.current);
+  }, [startInterval]);
+
+  const pause = useCallback(() => {
+    if (statusRef.current !== 'RUNNING') return;
+    statusRef.current = 'PAUSED';
+    stopInterval();
+    setState((prev) => ({ ...prev, status: 'PAUSED' }));
+  }, [stopInterval]);
+
+  const resume = useCallback(() => {
+    if (statusRef.current !== 'PAUSED') return;
+    statusRef.current = 'RUNNING';
+    setState((prev) => ({ ...prev, status: 'RUNNING' }));
+    startInterval(speedRef.current);
+  }, [startInterval]);
+
+  const restart = useCallback(() => {
+    stopInterval();
+    initEngine();
+    setState(buildInitialState(candles, initialBalance));
+  }, [stopInterval, initEngine, candles, initialBalance]);
+
+  const saveResults = useCallback(() => {
+    const allTrades = portfolioRef.current?.getTrades() ?? [];
+    const metrics = calculateMetrics(allTrades, initialBalance);
+    const filename = `backtest-results-${Date.now()}.json`;
+    writeFileSync(filename, JSON.stringify({ trades: allTrades, metrics }, null, 2));
+  }, [initialBalance]);
+
+  const setSpeed = useCallback(
+    (newSpeed: SpeedLevel) => {
+      speedRef.current = newSpeed;
+      setSpeedState(newSpeed);
+      if (statusRef.current === 'RUNNING') startInterval(newSpeed);
+    },
+    [startInterval],
+  );
+
+  const increaseSpeed = useCallback(() => {
+    const idx = SPEED_LEVELS.indexOf(speedRef.current);
+    const newSpeed = SPEED_LEVELS[Math.min(idx + 1, SPEED_LEVELS.length - 1)] ?? speedRef.current;
+    setSpeed(newSpeed);
+  }, [setSpeed]);
+
+  const decreaseSpeed = useCallback(() => {
+    const idx = SPEED_LEVELS.indexOf(speedRef.current);
+    const newSpeed = SPEED_LEVELS[Math.max(idx - 1, 0)] ?? speedRef.current;
+    setSpeed(newSpeed);
+  }, [setSpeed]);
+
+  // ── Lifecycle ────────────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    initEngine();
+    return stopInterval;
+  }, [initEngine, stopInterval]);
+
+  return {
+    state,
+    speed,
+    start,
+    pause,
+    resume,
+    restart,
+    saveResults,
+    setSpeed,
+    increaseSpeed,
+    decreaseSpeed,
+  };
+}

--- a/apps/trading-simulator/src/tui/hooks/useBacktest.ts
+++ b/apps/trading-simulator/src/tui/hooks/useBacktest.ts
@@ -162,8 +162,10 @@ export function useBacktest(
 
     const progressStr = tm.progress();
     const parts = progressStr.split(' / ');
-    const processed = parseInt((parts[0] ?? '0').replace(/,/g, ''), 10);
-    const total = parseInt((parts[1] ?? '1').replace(/,/g, ''), 10);
+    const rawProcessed = parseInt((parts[0] ?? '0').replace(/,/g, ''), 10);
+    const rawTotal = parseInt((parts[1] ?? '1').replace(/,/g, ''), 10);
+    const processed = Number.isNaN(rawProcessed) ? 0 : rawProcessed;
+    const total = Number.isNaN(rawTotal) ? 1 : rawTotal;
 
     setState({
       status: done ? 'COMPLETE' : statusRef.current,

--- a/apps/trading-simulator/src/tui/hooks/useBacktest.ts
+++ b/apps/trading-simulator/src/tui/hooks/useBacktest.ts
@@ -98,6 +98,7 @@ export function useBacktest(
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const statusRef = useRef<BacktestStatus>('IDLE');
   const speedRef = useRef<SpeedLevel>(10);
+  const recentTradesRef = useRef<ExecutedTrade[]>([]);
 
   // ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -155,6 +156,12 @@ export function useBacktest(
       strategy.onTradeExecuted(trade);
     }
 
+    // Maintain a capped ring buffer of the 8 most recent trades
+    if (newTrades.length > 0) {
+      const combined = recentTradesRef.current.concat(newTrades);
+      recentTradesRef.current = combined.length > 8 ? combined.slice(-8) : combined;
+    }
+
     if (done) {
       statusRef.current = 'COMPLETE';
       stopInterval();
@@ -177,7 +184,7 @@ export function useBacktest(
       totalCandles: total,
       currentTimestamp: lastWindow ? new Date(lastWindow[2].open_time) : new Date(0),
       progress: total > 0 ? (processed / total) * 100 : 0,
-      trades: allTrades.slice(-8),
+      trades: recentTradesRef.current,
       metrics: calculateMetrics(allTrades, initialBalance),
     });
   }, [strategy, initialBalance, stopInterval]);
@@ -227,6 +234,7 @@ export function useBacktest(
   const restart = useCallback(() => {
     stopInterval();
     initEngine();
+    recentTradesRef.current = [];
     setState(buildInitialState(candles, initialBalance));
   }, [stopInterval, initEngine, candles, initialBalance]);
 

--- a/apps/trading-simulator/src/tui/hooks/useKeyboard.ts
+++ b/apps/trading-simulator/src/tui/hooks/useKeyboard.ts
@@ -1,0 +1,70 @@
+import { useInput } from 'ink';
+import type { BacktestStatus } from '../types.js';
+
+interface UseKeyboardOptions {
+  status: BacktestStatus;
+  onStart: () => void;
+  onPause: () => void;
+  onResume: () => void;
+  onRestart: () => void;
+  onSave: () => void;
+  onQuit: () => void;
+  onSpeedUp: () => void;
+  onSpeedDown: () => void;
+}
+
+/**
+ * Binds keyboard controls to backtest actions.
+ *
+ * Keys:
+ *   SPACE   – Start (IDLE) / Pause (RUNNING) / Resume (PAUSED)
+ *   R       – Restart
+ *   S       – Save results
+ *   Q       – Quit
+ *   ↑       – Increase speed
+ *   ↓       – Decrease speed
+ */
+export function useKeyboard({
+  status,
+  onStart,
+  onPause,
+  onResume,
+  onRestart,
+  onSave,
+  onQuit,
+  onSpeedUp,
+  onSpeedDown,
+}: UseKeyboardOptions): void {
+  useInput((input, key) => {
+    if (input === ' ') {
+      if (status === 'IDLE') onStart();
+      else if (status === 'RUNNING') onPause();
+      else if (status === 'PAUSED') onResume();
+      return;
+    }
+
+    if (input === 'r' || input === 'R') {
+      onRestart();
+      return;
+    }
+
+    if (input === 's' || input === 'S') {
+      onSave();
+      return;
+    }
+
+    if (input === 'q' || input === 'Q') {
+      onQuit();
+      return;
+    }
+
+    if (key.upArrow) {
+      onSpeedUp();
+      return;
+    }
+
+    if (key.downArrow) {
+      onSpeedDown();
+    }
+  });
+}

--- a/apps/trading-simulator/src/tui/types.ts
+++ b/apps/trading-simulator/src/tui/types.ts
@@ -1,0 +1,59 @@
+import type { CandleLabel } from '@crypto-terminal/trade-formula';
+import type { OhlcCandle, ExecutedTrade, TradeSignal, StrategyRunner } from '../engine/types.js';
+import type { PerformanceMetrics } from '../shared/metrics.js';
+
+// ── Backtest status ────────────────────────────────────────────────────────────
+
+export type BacktestStatus = 'IDLE' | 'RUNNING' | 'PAUSED' | 'COMPLETE';
+
+// ── Speed level (0 = MAX) ─────────────────────────────────────────────────────
+
+export type SpeedLevel = 1 | 10 | 100 | 1000 | 0;
+
+// ── Pattern analysis data (from strategy metadata or basic classification) ────
+
+export interface PatternAnalysisData {
+  c1Label: CandleLabel;
+  c2Label: CandleLabel;
+  c3Label: CandleLabel;
+  upProbability?: number;
+  downProbability?: number;
+  momentumScores?: [number, number, number];
+  sequenceSlope?: number;
+  volatilityProxy?: number;
+  directionalAgreement?: number;
+  wickRatios?: [number, number, number];
+  route?: string;
+  conviction?: string;
+}
+
+// ── Backtest state managed by useBacktest ─────────────────────────────────────
+
+export interface BacktestState {
+  status: BacktestStatus;
+  currentCandles: [OhlcCandle, OhlcCandle, OhlcCandle] | null;
+  patternData: PatternAnalysisData | null;
+  tradeSignal: TradeSignal | null;
+  currentBalance: number;
+  candlesProcessed: number;
+  totalCandles: number;
+  currentTimestamp: Date;
+  /** Progress percentage 0–100 */
+  progress: number;
+  /** Last 8 completed trades */
+  trades: ExecutedTrade[];
+  metrics: PerformanceMetrics;
+}
+
+// ── Props for the TUI App root component ─────────────────────────────────────
+
+export interface TuiAppProps {
+  candles: OhlcCandle[];
+  strategy: StrategyRunner;
+  strategyName: string;
+  instrument: string;
+  timeframe: string;
+  initialBalance: number;
+  riskPercent: number;
+  tpMultiplier: number;
+}

--- a/apps/trading-simulator/src/tui/utils/formatting.ts
+++ b/apps/trading-simulator/src/tui/utils/formatting.ts
@@ -19,6 +19,8 @@ export function formatTimestamp(date: Date): string {
 }
 
 export function formatNumber(value: number, decimals = 3): string {
+  if (Number.isNaN(value)) return 'NaN';
+  if (!Number.isFinite(value)) return value > 0 ? '∞' : '-∞';
   return value.toFixed(decimals);
 }
 

--- a/apps/trading-simulator/src/tui/utils/formatting.ts
+++ b/apps/trading-simulator/src/tui/utils/formatting.ts
@@ -1,0 +1,73 @@
+// ── Currency / percent formatting ─────────────────────────────────────────────
+
+export function formatCurrency(value: number): string {
+  return `$${value.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+export function formatPercent(value: number): string {
+  const sign = value >= 0 ? '+' : '';
+  return `${sign}${value.toFixed(2)}%`;
+}
+
+/** "MM-DD HH:mm" */
+export function formatTimestamp(date: Date): string {
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  const dd = String(date.getDate()).padStart(2, '0');
+  const hh = String(date.getHours()).padStart(2, '0');
+  const min = String(date.getMinutes()).padStart(2, '0');
+  return `${mm}-${dd} ${hh}:${min}`;
+}
+
+export function formatNumber(value: number, decimals = 3): string {
+  return value.toFixed(decimals);
+}
+
+// ── Equity curve ASCII chart ──────────────────────────────────────────────────
+
+/**
+ * Render a filled ASCII bar chart from a list of balance values.
+ *
+ * Returns an array of strings, one per row (top to bottom).
+ * Each string is exactly `width` characters wide.
+ */
+export function renderEquityCurve(values: number[], width: number, height: number): string[] {
+  if (values.length === 0 || width === 0 || height === 0) {
+    return Array(height).fill(' '.repeat(width));
+  }
+
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min;
+
+  // Sample values to fit width
+  const sampled: number[] = [];
+  for (let i = 0; i < width; i++) {
+    const idx = Math.floor((i / width) * values.length);
+    sampled.push(values[Math.min(idx, values.length - 1)]!);
+  }
+
+  // Normalize each sample to a row index (0 = bottom, height-1 = top)
+  const normalized = sampled.map((v) =>
+    range > 0
+      ? Math.round(((v - min) / range) * (height - 1))
+      : Math.floor(height / 2),
+  );
+
+  // Build rows from top (height-1) to bottom (0)
+  const rows: string[] = [];
+  for (let row = height - 1; row >= 0; row--) {
+    let line = '';
+    for (let col = 0; col < width; col++) {
+      line += (normalized[col] ?? 0) >= row ? '█' : ' ';
+    }
+    rows.push(line);
+  }
+
+  return rows;
+}
+
+// ── Speed level label ─────────────────────────────────────────────────────────
+
+export function formatSpeed(speed: number): string {
+  return speed === 0 ? 'MAX' : `${speed}x`;
+}

--- a/apps/trading-simulator/src/tui/utils/formatting.ts
+++ b/apps/trading-simulator/src/tui/utils/formatting.ts
@@ -37,8 +37,8 @@ export function renderEquityCurve(values: number[], width: number, height: numbe
     return Array(height).fill(' '.repeat(width));
   }
 
-  const min = Math.min(...values);
-  const max = Math.max(...values);
+  const min = values.reduce((a, b) => (b < a ? b : a), values[0]!);
+  const max = values.reduce((a, b) => (b > a ? b : a), values[0]!);
   const range = max - min;
 
   // Sample values to fit width

--- a/apps/trading-simulator/tsconfig.json
+++ b/apps/trading-simulator/tsconfig.json
@@ -7,7 +7,8 @@
     "rootDir": "src",
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "jsx": "react-jsx"
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
Implements the terminal user interface for the backtest simulator using `ink` (React for terminals), as described in issue #53.

Closes #53

Generated with [Claude Code](https://claude.ai/code)