### PR TITLE
Add multi-instrument support and enhance trading features

### DIFF
--- a/apps/trading-simulator/.env.example
+++ b/apps/trading-simulator/.env.example
@@ -1,11 +1,10 @@
 # Required: PostgreSQL connection string for the crypto_terminal database
 DATABASE_URL=postgres://user:password@localhost:5432/crypto_terminal
 
-# Optional: instrument and timeframe to backtest (defaults shown)
-INSTRUMENT=BTCUSDT
+# Optional: timeframe to backtest (default shown)
 TIMEFRAME=5m
 
-# Optional: starting portfolio balance in USD (default: 1000, must be > 0)
+# Optional: starting portfolio balance in USD per instrument (default: 1000, must be > 0)
 INITIAL_BALANCE=1000
 
 # Optional: pino log level — trace | debug | info | warn | error (default: info)

--- a/apps/trading-simulator/README.md
+++ b/apps/trading-simulator/README.md
@@ -1,6 +1,6 @@
 # trading-simulator
 
-Backtesting engine for OHLCV-based trading strategies. Iterates through historical BTCUSDT 5-minute candles, runs a strategy against a sliding 3-candle window, and tracks portfolio performance (balance, SL/TP hits, P&L).
+Backtesting engine for OHLCV-based trading strategies. Iterates through historical candles for one or more instruments, runs a strategy against a sliding 3-candle window, and tracks portfolio performance (balance, SL/TP hits, P&L).
 
 ## Prerequisites
 
@@ -14,7 +14,6 @@ Backtesting engine for OHLCV-based trading strategies. Iterates through historic
 
 ```env
 DATABASE_URL=postgres://user:password@localhost:5432/crypto_terminal
-INSTRUMENT=BTCUSDT
 TIMEFRAME=5m
 INITIAL_BALANCE=1000
 LOG_LEVEL=info
@@ -42,6 +41,12 @@ Use a specific strategy with custom settings:
 pnpm tui -- --strategy=pattern-based-v1
 pnpm tui -- --strategy=pattern-based-v1 --balance=5000
 pnpm tui -- --strategy=pattern-based-v1 --balance=5000 --risk=2 --tp-multiplier=1.5
+```
+
+Pass instruments directly to skip the interactive prompt:
+
+```bash
+pnpm tui -- --strategy=pattern-based-v1 --instruments=BTCUSDT,ETHUSDT
 ```
 
 ### CLI Backtest (headless-friendly)
@@ -93,7 +98,8 @@ pnpm start -- --strategy=pattern-based-v1 --output=run-2024-01-15.json
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--strategy=<name>` | Strategy to run | `dummy` |
-| `--balance=<number>` | Initial balance in USD | From `INITIAL_BALANCE` env |
+| `--instruments=<list>` | Comma-separated instrument symbols (skips interactive prompt) | Interactive prompt |
+| `--balance=<number>` | Initial balance in USD per instrument | From `INITIAL_BALANCE` env |
 | `--risk=<number>` | Risk % per trade (0–100) | From strategy default |
 | `--tp-multiplier=<number>` | Take-profit multiplier (must be > 0) | From strategy default |
 
@@ -102,7 +108,8 @@ pnpm start -- --strategy=pattern-based-v1 --output=run-2024-01-15.json
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--strategy=<name>` | Strategy to run | `dummy` |
-| `--balance=<number>` | Initial balance in USD | From `INITIAL_BALANCE` env |
+| `--instruments=<list>` | Comma-separated instrument symbols (skips interactive prompt) | Interactive prompt |
+| `--balance=<number>` | Initial balance in USD per instrument | From `INITIAL_BALANCE` env |
 | `--risk=<number>` | Risk % per trade (0–100) | From strategy default |
 | `--tp-multiplier=<number>` | Take-profit multiplier (must be > 0) | From strategy default |
 | `--headless` | Run without TUI, auto-save on completion | `false` |
@@ -153,6 +160,7 @@ Each row in the trade log records:
 | Column | Description |
 |--------|-------------|
 | `#` | Sequential trade ID |
+| `Ticker` | Instrument symbol (e.g. `BTCUSDT`) |
 | `Time` | Entry timestamp |
 | `Type` | `LONG` or `SHORT` |
 | `Entry` | Entry price |

--- a/apps/trading-simulator/src/config.ts
+++ b/apps/trading-simulator/src/config.ts
@@ -11,7 +11,6 @@ export const config = {
   database: {
     url: requireEnv('DATABASE_URL'),
   },
-  instrument: process.env.INSTRUMENT ?? 'BTCUSDT',
   timeframe: process.env.TIMEFRAME ?? '5m',
   initialBalance: (() => {
     const v = Number(process.env.INITIAL_BALANCE ?? '1000');

--- a/apps/trading-simulator/src/db/queries.ts
+++ b/apps/trading-simulator/src/db/queries.ts
@@ -5,6 +5,19 @@ import type { OhlcCandle } from '../engine/types.js';
 import type { CandleLabel } from '@crypto-terminal/trade-formula';
 
 /**
+ * Fetch all unique instrument names available in the ohlcv_candles table,
+ * sorted alphabetically. Used to populate the instrument selection prompt.
+ */
+export async function fetchAvailableInstruments(db: Db): Promise<string[]> {
+  const rows = await db
+    .selectDistinct({ instrument: ohlcvCandles.instrument })
+    .from(ohlcvCandles)
+    .orderBy(asc(ohlcvCandles.instrument));
+
+  return rows.map((r) => r.instrument);
+}
+
+/**
  * Fetch all OHLCV candles for the given instrument and timeframe,
  * ordered chronologically. Returns the full set as an in-memory array
  * ready for TimeMachine iteration.

--- a/apps/trading-simulator/src/engine/backtest-runner.ts
+++ b/apps/trading-simulator/src/engine/backtest-runner.ts
@@ -18,6 +18,8 @@ export interface BacktestRunnerOptions {
   candles: OhlcCandle[];
   strategy: StrategyRunner;
   initialBalance: number;
+  /** Instrument being backtested — tagged on every ExecutedTrade. */
+  instrument?: string;
   /** Log progress every N candles. Default 1000. */
   progressInterval?: number;
   /**
@@ -41,6 +43,7 @@ export class BacktestRunner extends EventEmitter {
   private readonly candles: OhlcCandle[];
   private readonly strategy: StrategyRunner;
   private readonly initialBalance: number;
+  private readonly instrument: string;
   private readonly progressInterval: number;
   private readonly haltOnStrategyError: boolean;
 
@@ -49,13 +52,14 @@ export class BacktestRunner extends EventEmitter {
     this.candles = options.candles;
     this.strategy = options.strategy;
     this.initialBalance = options.initialBalance;
+    this.instrument = options.instrument ?? '';
     this.progressInterval = options.progressInterval ?? 1000;
     this.haltOnStrategyError = options.haltOnStrategyError ?? false;
   }
 
   run(): BacktestResults {
     const timeMachine = new TimeMachine(this.candles);
-    const portfolio = new Portfolio(this.initialBalance);
+    const portfolio = new Portfolio(this.initialBalance, this.instrument);
 
     let windowCount = 0;
     let strategyErrorCount = 0;

--- a/apps/trading-simulator/src/engine/portfolio.ts
+++ b/apps/trading-simulator/src/engine/portfolio.ts
@@ -23,12 +23,14 @@ export class Portfolio {
   private position: OpenPosition | null = null;
   private readonly completedTrades: ExecutedTrade[] = [];
   private tradeIdCounter = 0;
+  private readonly instrument: string;
 
-  constructor(initialBalance: number) {
+  constructor(initialBalance: number, instrument = '') {
     if (initialBalance <= 0) {
       throw new Error(`initialBalance must be positive, got ${initialBalance}`);
     }
     this.balance = initialBalance;
+    this.instrument = instrument;
   }
 
   // ── Position lifecycle ──────────────────────────────────────────────────────
@@ -136,6 +138,7 @@ export class Portfolio {
     // strategies must bake leverage into dollarRisk themselves if needed.
     const trade: ExecutedTrade = {
       id: ++this.tradeIdCounter,
+      instrument: this.instrument,
       entryTimestamp,
       exitTimestamp: new Date(exitTimestamp * 1000),
       direction: side,

--- a/apps/trading-simulator/src/engine/types.ts
+++ b/apps/trading-simulator/src/engine/types.ts
@@ -31,6 +31,7 @@ export interface TradeSignal {
 
 export interface ExecutedTrade {
   id: number;
+  instrument: string;
   entryTimestamp: Date;
   exitTimestamp: Date;
   direction: 'LONG' | 'SHORT';

--- a/apps/trading-simulator/src/index.ts
+++ b/apps/trading-simulator/src/index.ts
@@ -3,12 +3,13 @@ import pg from 'pg';
 import pino from 'pino';
 import { config } from './config.js';
 import { createDb } from './db/client.js';
-import { fetchAllCandles } from './db/queries.js';
+import { fetchAllCandles, fetchAvailableInstruments } from './db/queries.js';
 import { BacktestRunner } from './engine/backtest-runner.js';
 import type { ExecutedTrade, OhlcCandle, StrategyRunner, TradeSignal } from './engine/types.js';
 import { calculateMetrics } from './shared/metrics.js';
 import { InMemoryTradeLog } from './shared/execution-log.js';
 import { loadStrategy, KNOWN_STRATEGIES } from './strategies/loader.js';
+import { promptInstrumentSelection } from './shared/instrument-selector.js';
 
 const log = pino({ level: config.logLevel });
 const { Pool } = pg;
@@ -35,6 +36,7 @@ const balanceArg = getArg('--balance=');
 const riskArg = getArg('--risk=');
 const tpArg = getArg('--tp-multiplier=');
 const outputArg = getArg('--output=');
+const instrumentsArg = getArg('--instruments=');
 const headless = hasFlag('--headless');
 const haltOnError = hasFlag('--halt-on-error');
 
@@ -95,13 +97,15 @@ const dummyStrategy: StrategyRunner = {
 
 function saveResults(
   strategyName: string,
+  selectedInstruments: string[],
   trades: ExecutedTrade[],
   initialBal: number,
+  totalInitialBal: number,
   finalBal: number,
   strategyErrorCount: number,
   outputPath?: string,
 ): void {
-  const metrics = calculateMetrics(trades, initialBal);
+  const metrics = calculateMetrics(trades, totalInitialBal);
   const timestamp = new Date().toISOString();
   const safeStrategy = strategyName.replace(/[^a-z0-9-]/gi, '-');
   const safeTimestamp = timestamp.replace(/[:.]/g, '-').slice(0, 19);
@@ -112,9 +116,10 @@ function saveResults(
   const payload = {
     metadata: {
       strategy: strategyName,
-      instrument: config.instrument,
+      instruments: selectedInstruments,
       timeframe: config.timeframe,
       initialBalance: initialBal,
+      totalInitialBalance: totalInitialBal,
       finalBalance: finalBal,
       runDate: timestamp,
       strategyErrors: strategyErrorCount,
@@ -166,101 +171,167 @@ async function main() {
 
     const db = createDb(pool);
 
-    let strategy: StrategyRunner;
-    if (strategyArg === 'dummy') {
-      strategy = dummyStrategy;
+    // Fetch available instruments
+    const availableInstruments = await fetchAvailableInstruments(db);
+
+    // Resolve instrument selection
+    let selectedInstruments: string[];
+    if (instrumentsArg) {
+      selectedInstruments = instrumentsArg
+        .split(',')
+        .map((s) => s.trim())
+        .filter((s) => s !== '');
+
+      const invalid = selectedInstruments.filter((i) => !availableInstruments.includes(i));
+      if (invalid.length > 0) {
+        log.error(
+          { invalid, available: availableInstruments },
+          '[cli] Unknown instrument(s) specified via --instruments',
+        );
+        process.exit(1);
+      }
+      if (selectedInstruments.length === 0) {
+        log.error('[cli] --instruments argument is empty. Specify at least one instrument.');
+        process.exit(1);
+      }
     } else {
       try {
-        strategy = await loadStrategy(strategyArg as Parameters<typeof loadStrategy>[0], db, {
-          instrument: config.instrument,
-          timeframe: config.timeframe,
-          initialBalance,
-          ...(riskPct !== undefined && { riskPct }),
-          ...(tpMultiplier !== undefined && { tpMultiplier }),
-        });
-        log.info({ strategy: strategyArg }, '[cli] Strategy loaded');
+        selectedInstruments = await promptInstrumentSelection(availableInstruments, '[cli]');
       } catch (err) {
-        log.error({ err, strategy: strategyArg }, '[cli] Failed to load strategy');
+        log.error({ err }, '[cli] Instrument selection failed');
         process.exit(1);
       }
     }
 
-    log.info(
-      { instrument: config.instrument, timeframe: config.timeframe },
-      '[backtest] Fetching candles',
-    );
+    log.info({ instruments: selectedInstruments }, '[cli] Instruments selected');
 
-    const candles = await fetchAllCandles(db, config.instrument, config.timeframe);
+    // Run backtest for each instrument sequentially, collecting all trades
+    const allTrades: ExecutedTrade[] = [];
+    let totalFinalBalance = 0;
+    let totalStrategyErrors = 0;
+    let strategyName = strategyArg;
 
-    log.info({ count: candles.length }, '[backtest] Candles loaded');
+    for (const instrument of selectedInstruments) {
+      let strategy: StrategyRunner;
+      if (strategyArg === 'dummy') {
+        strategy = dummyStrategy;
+      } else {
+        try {
+          strategy = await loadStrategy(strategyArg as Parameters<typeof loadStrategy>[0], db, {
+            instrument,
+            timeframe: config.timeframe,
+            initialBalance,
+            ...(riskPct !== undefined && { riskPct }),
+            ...(tpMultiplier !== undefined && { tpMultiplier }),
+          });
+          strategyName = strategy.name;
+          log.info({ strategy: strategyArg, instrument }, '[cli] Strategy loaded');
+        } catch (err) {
+          log.error({ err, strategy: strategyArg, instrument }, '[cli] Failed to load strategy');
+          process.exit(1);
+        }
+      }
 
-    if (candles.length < 3) {
-      log.error({ count: candles.length }, '[backtest] Not enough candles to run a backtest');
-      process.exit(1);
-    }
+      log.info(
+        { instrument, timeframe: config.timeframe },
+        '[backtest] Fetching candles',
+      );
 
-    log.info(
-      {
-        strategy: strategy.name,
-        version: strategy.version,
-        initialBalance,
-        headless,
-        haltOnError,
-      },
-      '[backtest] Starting',
-    );
+      const candles = await fetchAllCandles(db, instrument, config.timeframe);
 
-    const runner = new BacktestRunner({
-      candles,
-      strategy,
-      initialBalance,
-      haltOnStrategyError: haltOnError,
-    });
+      log.info({ count: candles.length, instrument }, '[backtest] Candles loaded');
 
-    runner.on('tradeClosed', (trade) => {
+      if (candles.length < 3) {
+        log.error({ count: candles.length, instrument }, '[backtest] Not enough candles to run a backtest');
+        process.exit(1);
+      }
+
       log.info(
         {
-          id: trade.id,
-          direction: trade.direction,
-          exitReason: trade.exitReason,
-          pnlDollar: trade.pnlDollar.toFixed(2),
-          pnlPercent: trade.pnlPercent.toFixed(2),
+          strategy: strategy.name,
+          version: strategy.version,
+          instrument,
+          initialBalance,
+          headless,
+          haltOnError,
         },
-        '[trade] Closed',
+        '[backtest] Starting',
       );
-    });
 
-    runner.on('strategyError', (err, candles) => {
-      log.warn(
-        { err, c3Time: candles[2].open_time },
-        '[strategy] Error in analyze() — skipping candle',
+      const runner = new BacktestRunner({
+        candles,
+        strategy,
+        initialBalance,
+        instrument,
+        haltOnStrategyError: haltOnError,
+      });
+
+      runner.on('tradeClosed', (trade) => {
+        log.info(
+          {
+            id: trade.id,
+            instrument: trade.instrument,
+            direction: trade.direction,
+            exitReason: trade.exitReason,
+            pnlDollar: trade.pnlDollar.toFixed(2),
+            pnlPercent: trade.pnlPercent.toFixed(2),
+          },
+          '[trade] Closed',
+        );
+      });
+
+      runner.on('strategyError', (err, candles) => {
+        log.warn(
+          { err, instrument, c3Time: candles[2].open_time },
+          '[strategy] Error in analyze() — skipping candle',
+        );
+      });
+
+      const results = runner.run();
+
+      log.info(
+        {
+          instrument,
+          initialBalance: results.initialBalance.toFixed(2),
+          finalBalance: results.finalBalance.toFixed(2),
+          totalPnl: results.totalPnlDollar.toFixed(2),
+          totalTrades: results.totalTrades,
+          wins: results.winCount,
+          losses: results.lossCount,
+          winRate: `${results.winRate.toFixed(1)}%`,
+          strategyErrors: results.strategyErrorCount,
+        },
+        '[backtest] Complete',
       );
-    });
 
-    const results = runner.run();
+      allTrades.push(...results.trades);
+      totalFinalBalance += results.finalBalance;
+      totalStrategyErrors += results.strategyErrorCount;
+    }
+
+    const totalInitialBalance = initialBalance * selectedInstruments.length;
 
     log.info(
       {
-        initialBalance: results.initialBalance.toFixed(2),
-        finalBalance: results.finalBalance.toFixed(2),
-        totalPnl: results.totalPnlDollar.toFixed(2),
-        totalTrades: results.totalTrades,
-        wins: results.winCount,
-        losses: results.lossCount,
-        winRate: `${results.winRate.toFixed(1)}%`,
-        strategyErrors: results.strategyErrorCount,
+        instruments: selectedInstruments,
+        totalInitialBalance: totalInitialBalance.toFixed(2),
+        totalFinalBalance: totalFinalBalance.toFixed(2),
+        totalTrades: allTrades.length,
+        strategyErrors: totalStrategyErrors,
       },
-      '[backtest] Complete',
+      '[backtest] All instruments complete',
     );
 
     // In headless mode (or when --output is specified), auto-save results
     if (headless || outputArg) {
       saveResults(
-        strategy.name,
-        results.trades,
-        results.initialBalance,
-        results.finalBalance,
-        results.strategyErrorCount,
+        strategyName,
+        selectedInstruments,
+        allTrades,
+        initialBalance,
+        totalInitialBalance,
+        totalFinalBalance,
+        totalStrategyErrors,
         outputArg,
       );
     }

--- a/apps/trading-simulator/src/shared/execution-log.ts
+++ b/apps/trading-simulator/src/shared/execution-log.ts
@@ -63,6 +63,7 @@ export class InMemoryTradeLog implements TradeLog {
 
     const headers = [
       'id',
+      'instrument',
       'strategyName',
       'strategyVersion',
       'entryTimestamp',
@@ -83,6 +84,7 @@ export class InMemoryTradeLog implements TradeLog {
     const rows = this.trades.map((t) => {
       const cells = [
         t.id,
+        csvEscape(t.instrument),
         csvEscape(t.strategyName),
         csvEscape(t.strategyVersion),
         t.entryTimestamp.toISOString(),

--- a/apps/trading-simulator/src/shared/instrument-selector.ts
+++ b/apps/trading-simulator/src/shared/instrument-selector.ts
@@ -1,0 +1,73 @@
+import readline from 'node:readline';
+
+/**
+ * Displays an interactive numbered list of instruments and prompts the user
+ * to select one or more. Returns the selected instrument symbols.
+ *
+ * @param instruments - Available instrument symbols fetched from the DB.
+ * @param label       - Context label shown in the prompt header (e.g. "[tui]").
+ * @throws Error if no instruments are available, or if the user's input is invalid.
+ */
+export async function promptInstrumentSelection(
+  instruments: string[],
+  label = '[sim]',
+): Promise<string[]> {
+  if (instruments.length === 0) {
+    throw new Error('No instruments found in the database. Make sure candle data has been collected.');
+  }
+
+  process.stdout.write(`\n${label} Available instruments:\n`);
+  for (let i = 0; i < instruments.length; i++) {
+    process.stdout.write(`  [${i + 1}] ${instruments[i]}\n`);
+  }
+  process.stdout.write('\n');
+
+  const answer = await question(
+    `${label} Enter instrument numbers (comma-separated) or "all": `,
+  );
+
+  const trimmed = answer.trim().toLowerCase();
+
+  if (trimmed === 'all') {
+    process.stdout.write('\n');
+    return [...instruments];
+  }
+
+  const parsed = trimmed
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s !== '');
+
+  if (parsed.length === 0) {
+    throw new Error('No instruments selected. You must select at least one instrument to run the simulation.');
+  }
+
+  const selected: string[] = [];
+  for (const token of parsed) {
+    const idx = Number(token) - 1;
+    if (!Number.isInteger(idx) || idx < 0 || idx >= instruments.length) {
+      throw new Error(
+        `Invalid selection: "${token}". Enter numbers between 1 and ${instruments.length}, or "all".`,
+      );
+    }
+    const instrument = instruments[idx]!;
+    if (!selected.includes(instrument)) {
+      selected.push(instrument);
+    }
+  }
+
+  process.stdout.write('\n');
+  return selected;
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+function question(prompt: string): Promise<string> {
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    rl.question(prompt, (answer) => {
+      rl.close();
+      resolve(answer);
+    });
+  });
+}

--- a/apps/trading-simulator/src/tui.tsx
+++ b/apps/trading-simulator/src/tui.tsx
@@ -2,23 +2,24 @@
  * TUI entry point for the backtest simulator.
  *
  * Usage:
- *   tsx --env-file .env src/tui.tsx [--strategy=pattern-based-v1]
+ *   tsx --env-file .env src/tui.tsx [--strategy=pattern-based-v1] [--instruments=BTCUSDT,ETHUSDT]
  *
- * Environment variables (same as index.ts):
+ * Environment variables:
  *   DATABASE_URL      – PostgreSQL connection string
- *   INSTRUMENT        – e.g. BTCUSDT (default)
  *   TIMEFRAME         – e.g. 5m (default)
- *   INITIAL_BALANCE   – starting USD balance (default 1000)
+ *   INITIAL_BALANCE   – starting USD balance per instrument (default 1000)
  */
 import pg from 'pg';
 import { render } from 'ink';
 import { config } from './config.js';
 import { createDb } from './db/client.js';
-import { fetchAllCandles } from './db/queries.js';
+import { fetchAllCandles, fetchAvailableInstruments } from './db/queries.js';
 import { loadStrategy, KNOWN_STRATEGIES } from './strategies/loader.js';
 import { BASE_STRATEGY_CONFIG } from './strategies/base-config.js';
 import type { OhlcCandle, StrategyRunner, TradeSignal, ExecutedTrade } from './engine/types.js';
 import { App } from './tui/App.js';
+import type { InstrumentData } from './tui/types.js';
+import { promptInstrumentSelection } from './shared/instrument-selector.js';
 
 const { Pool } = pg;
 
@@ -29,6 +30,7 @@ const strategyArg = args.find((a) => a.startsWith('--strategy='))?.split('=')[1]
 const balanceArg = args.find((a) => a.startsWith('--balance='))?.split('=')[1];
 const riskArg = args.find((a) => a.startsWith('--risk='))?.split('=')[1];
 const tpArg = args.find((a) => a.startsWith('--tp-multiplier='))?.split('=')[1];
+const instrumentsArg = args.find((a) => a.startsWith('--instruments='))?.split('=')[1];
 
 const initialBalance = (() => {
   if (balanceArg !== undefined) {
@@ -105,34 +107,72 @@ async function main() {
 
     const db = createDb(pool);
 
-    // Load strategy
-    let strategy: StrategyRunner;
-    if (strategyArg === 'dummy') {
-      strategy = dummyStrategy;
+    // Fetch available instruments
+    process.stdout.write('[tui] Fetching available instruments…\n');
+    const availableInstruments = await fetchAvailableInstruments(db);
+
+    // Resolve instrument selection
+    let selectedInstruments: string[];
+    if (instrumentsArg) {
+      selectedInstruments = instrumentsArg
+        .split(',')
+        .map((s) => s.trim())
+        .filter((s) => s !== '');
+
+      // Validate against DB
+      const invalid = selectedInstruments.filter((i) => !availableInstruments.includes(i));
+      if (invalid.length > 0) {
+        process.stderr.write(
+          `[tui] Unknown instrument(s): ${invalid.join(', ')}. Available: ${availableInstruments.join(', ')}\n`,
+        );
+        process.exit(1);
+      }
+      if (selectedInstruments.length === 0) {
+        process.stderr.write('[tui] --instruments argument is empty. Specify at least one instrument.\n');
+        process.exit(1);
+      }
     } else {
-      strategy = await loadStrategy(
-        strategyArg as Parameters<typeof loadStrategy>[0],
-        db,
-        {
-          instrument: config.instrument,
-          timeframe: config.timeframe,
-          initialBalance,
-          ...(riskPct !== undefined && { riskPct }),
-          ...(tpMultiplier !== undefined && { tpMultiplier }),
-        },
-      );
+      try {
+        selectedInstruments = await promptInstrumentSelection(availableInstruments, '[tui]');
+      } catch (err) {
+        process.stderr.write(`[tui] ${String(err)}\n`);
+        process.exit(1);
+      }
     }
 
-    process.stdout.write(`[tui] Strategy loaded: ${strategy.name} v${strategy.version}\n`);
+    process.stdout.write(`[tui] Selected instruments: ${selectedInstruments.join(', ')}\n`);
 
-    // Fetch candles
-    process.stdout.write('[tui] Loading candles…\n');
-    const candles = await fetchAllCandles(db, config.instrument, config.timeframe);
-    process.stdout.write(`[tui] Loaded ${candles.length} candles\n`);
+    // Load strategy and candles for each instrument
+    const instrumentDataList: InstrumentData[] = [];
 
-    if (candles.length < 3) {
-      process.stderr.write('[tui] Not enough candles to run (need at least 3)\n');
-      process.exit(1);
+    for (const instrument of selectedInstruments) {
+      let strategy: StrategyRunner;
+      if (strategyArg === 'dummy') {
+        strategy = dummyStrategy;
+      } else {
+        strategy = await loadStrategy(
+          strategyArg as Parameters<typeof loadStrategy>[0],
+          db,
+          {
+            instrument,
+            timeframe: config.timeframe,
+            initialBalance,
+            ...(riskPct !== undefined && { riskPct }),
+            ...(tpMultiplier !== undefined && { tpMultiplier }),
+          },
+        );
+      }
+
+      process.stdout.write(`[tui] Loading candles for ${instrument}…\n`);
+      const candles = await fetchAllCandles(db, instrument, config.timeframe);
+      process.stdout.write(`[tui] Loaded ${candles.length} candles for ${instrument}\n`);
+
+      if (candles.length < 3) {
+        process.stderr.write(`[tui] Not enough candles for ${instrument} (need at least 3)\n`);
+        process.exit(1);
+      }
+
+      instrumentDataList.push({ instrument, candles, strategy });
     }
 
     // Close pool (TUI loop takes over from here — no more DB needed)
@@ -144,10 +184,8 @@ async function main() {
     // Render TUI
     render(
       <App
-        candles={candles}
-        strategy={strategy}
-        strategyName={strategy.name}
-        instrument={config.instrument}
+        instruments={instrumentDataList}
+        strategyName={strategyArg}
         timeframe={config.timeframe}
         initialBalance={initialBalance}
         riskPercent={riskPct ?? BASE_STRATEGY_CONFIG.riskPct}

--- a/apps/trading-simulator/src/tui/App.tsx
+++ b/apps/trading-simulator/src/tui/App.tsx
@@ -11,10 +11,8 @@ import { PatternDisplay } from './components/PatternDisplay.js';
 import { Footer } from './components/Footer.js';
 
 export function App({
-  candles,
-  strategy,
+  instruments,
   strategyName,
-  instrument,
   timeframe,
   initialBalance,
   riskPercent,
@@ -32,7 +30,7 @@ export function App({
     saveResults,
     increaseSpeed,
     decreaseSpeed,
-  } = useBacktest(candles, strategy, initialBalance);
+  } = useBacktest(instruments, initialBalance);
 
   useKeyboard({
     status: state.status,
@@ -46,12 +44,14 @@ export function App({
     onSpeedDown: decreaseSpeed,
   });
 
+  const instrumentNames = instruments.map((d) => d.instrument);
+
   return (
     <Box flexDirection="column" height="100%">
       {/* Header */}
       <Header
         strategy={strategyName}
-        instrument={instrument}
+        instruments={instrumentNames}
         timeframe={timeframe}
         status={state.status}
         progress={state.progress}

--- a/apps/trading-simulator/src/tui/components/Header.tsx
+++ b/apps/trading-simulator/src/tui/components/Header.tsx
@@ -3,7 +3,7 @@ import type { BacktestStatus } from '../types.js';
 
 interface HeaderProps {
   strategy: string;
-  instrument: string;
+  instruments: string[];
   timeframe: string;
   status: BacktestStatus;
   progress: number;
@@ -23,7 +23,12 @@ const STATUS_LABELS: Record<BacktestStatus, string> = {
   COMPLETE: '✓ COMPLETE',
 };
 
-export function Header({ strategy, instrument, timeframe, status, progress }: HeaderProps) {
+function formatInstruments(instruments: string[]): string {
+  if (instruments.length <= 3) return instruments.join(', ');
+  return `${instruments.length} instruments`;
+}
+
+export function Header({ strategy, instruments, timeframe, status, progress }: HeaderProps) {
   const color = STATUS_COLORS[status];
   const label = STATUS_LABELS[status];
   const progressStr =
@@ -46,7 +51,7 @@ export function Header({ strategy, instrument, timeframe, status, progress }: He
           Strategy: <Text bold>{strategy}</Text>
         </Text>
         <Text color="white">
-          {instrument} {timeframe}
+          {formatInstruments(instruments)} {timeframe}
         </Text>
         <Text color={color}>
           {label}

--- a/apps/trading-simulator/src/tui/components/TradeLog.tsx
+++ b/apps/trading-simulator/src/tui/components/TradeLog.tsx
@@ -8,6 +8,7 @@ interface TradeLogProps {
 
 const COL_WIDTHS = {
   num:        6,
+  ticker:     10,
   time:       16,
   type:       5,
   entry:      12,
@@ -29,17 +30,19 @@ function HeaderRow() {
   return (
     <Box paddingX={1}>
       <Text bold color="gray">
-        {pad('#',      COL_WIDTHS.num,    false)}
+        {pad('#',       COL_WIDTHS.num,        false)}
         {'  '}
-        {pad('Time',   COL_WIDTHS.time,   false)}
+        {pad('Ticker',  COL_WIDTHS.ticker,     false)}
         {'  '}
-        {pad('Type',   COL_WIDTHS.type,   false)}
+        {pad('Time',    COL_WIDTHS.time,       false)}
         {'  '}
-        {pad('Entry',  COL_WIDTHS.entry,  true)}
+        {pad('Type',    COL_WIDTHS.type,       false)}
         {'  '}
-        {pad('SL',     COL_WIDTHS.sl,     true)}
+        {pad('Entry',   COL_WIDTHS.entry,      true)}
         {'  '}
-        {pad('TP',     COL_WIDTHS.tp,     true)}
+        {pad('SL',      COL_WIDTHS.sl,         true)}
+        {'  '}
+        {pad('TP',      COL_WIDTHS.tp,         true)}
         {'  '}
         {pad('Exit',    COL_WIDTHS.exit,       true)}
         {'  '}
@@ -47,7 +50,7 @@ function HeaderRow() {
         {'  '}
         {pad('P&L $',   COL_WIDTHS.pnlDollar,  true)}
         {'  '}
-        {pad('P&L %',    COL_WIDTHS.pnlPct,     true)}
+        {pad('P&L %',   COL_WIDTHS.pnlPct,     true)}
         {'  '}
         {pad('Result',  COL_WIDTHS.result,     false)}
       </Text>
@@ -64,34 +67,36 @@ function TradeRow({ trade }: { trade: ExecutedTrade }) {
   return (
     <Box paddingX={1}>
       <Text>
-        {pad(String(trade.id), COL_WIDTHS.num, false)}
+        {pad(String(trade.id),                              COL_WIDTHS.num,        false)}
         {'  '}
-        {pad(formatTimestamp(trade.entryTimestamp), COL_WIDTHS.time, false)}
+        {pad(trade.instrument,                              COL_WIDTHS.ticker,     false)}
+        {'  '}
+        {pad(formatTimestamp(trade.entryTimestamp),         COL_WIDTHS.time,       false)}
         {'  '}
         <Text color={directionColor}>
-          {pad(trade.direction, COL_WIDTHS.type, false)}
+          {pad(trade.direction,                             COL_WIDTHS.type,       false)}
         </Text>
         {'  '}
-        {pad(formatCurrency(trade.entryPrice),      COL_WIDTHS.entry,       true)}
+        {pad(formatCurrency(trade.entryPrice),              COL_WIDTHS.entry,      true)}
         {'  '}
-        {pad(formatCurrency(trade.slPrice),         COL_WIDTHS.sl,          true)}
+        {pad(formatCurrency(trade.slPrice),                 COL_WIDTHS.sl,         true)}
         {'  '}
-        {pad(formatCurrency(trade.tpPrice),         COL_WIDTHS.tp,          true)}
+        {pad(formatCurrency(trade.tpPrice),                 COL_WIDTHS.tp,         true)}
         {'  '}
-        {pad(formatCurrency(trade.exitPrice),       COL_WIDTHS.exit,        true)}
+        {pad(formatCurrency(trade.exitPrice),               COL_WIDTHS.exit,       true)}
         {'  '}
-        {pad(formatCurrency(trade.dollarRisk),      COL_WIDTHS.riskDollar,  true)}
+        {pad(formatCurrency(trade.dollarRisk),              COL_WIDTHS.riskDollar, true)}
         {'  '}
         <Text color={pnlColor}>
-          {pad(pnlDollarStr,                        COL_WIDTHS.pnlDollar,   true)}
+          {pad(pnlDollarStr,                                COL_WIDTHS.pnlDollar,  true)}
         </Text>
         {'  '}
         <Text color={pnlColor}>
-          {pad(formatPercent(trade.pnlPercent),     COL_WIDTHS.pnlPct,      true)}
+          {pad(formatPercent(trade.pnlPercent),             COL_WIDTHS.pnlPct,     true)}
         </Text>
         {'  '}
         <Text color={isWin ? 'green' : 'red'}>
-          {pad(isWin ? '✓ TP' : '✗ SL', COL_WIDTHS.result, false)}
+          {pad(isWin ? '✓ TP' : '✗ SL',                    COL_WIDTHS.result,     false)}
         </Text>
       </Text>
     </Box>
@@ -111,7 +116,7 @@ export function TradeLog({ trades }: TradeLogProps) {
           <Text color="gray">No trades yet</Text>
         </Box>
       ) : (
-        trades.map((trade) => <TradeRow key={trade.id} trade={trade} />)
+        trades.map((trade) => <TradeRow key={`${trade.instrument}-${trade.id}`} trade={trade} />)
       )}
     </Box>
   );

--- a/apps/trading-simulator/src/tui/hooks/useBacktest.ts
+++ b/apps/trading-simulator/src/tui/hooks/useBacktest.ts
@@ -6,7 +6,7 @@ import { TimeMachine } from '../../engine/time-machine.js';
 import { Portfolio } from '../../engine/portfolio.js';
 import { calculateMetrics } from '../../shared/metrics.js';
 import { InMemoryTradeLog } from '../../shared/execution-log.js';
-import type { BacktestState, BacktestStatus, PatternAnalysisData, SpeedLevel } from '../types.js';
+import type { BacktestState, BacktestStatus, PatternAnalysisData, SpeedLevel, InstrumentData } from '../types.js';
 
 // ── Speed → { intervalMs, batchSize } ────────────────────────────────────────
 
@@ -24,6 +24,16 @@ const SPEED_CONFIG: Record<SpeedLevel, SpeedConfig> = {
 };
 
 export const SPEED_LEVELS: SpeedLevel[] = [1, 10, 100, 1000, 0];
+
+// ── Per-instrument runtime state ──────────────────────────────────────────────
+
+interface InstrumentRuntime {
+  instrument: string;
+  strategy: StrategyRunner;
+  timeMachine: TimeMachine;
+  portfolio: Portfolio;
+  done: boolean;
+}
 
 // ── Pattern data extraction ───────────────────────────────────────────────────
 
@@ -66,15 +76,16 @@ function extractPatternData(
 
 // ── Initial state ─────────────────────────────────────────────────────────────
 
-function buildInitialState(candles: OhlcCandle[], initialBalance: number): BacktestState {
+function buildInitialState(instruments: InstrumentData[], initialBalance: number): BacktestState {
+  const totalCandles = instruments.reduce((sum, { candles }) => sum + candles.length, 0);
   return {
     status: 'IDLE',
     currentCandles: null,
     patternData: null,
     tradeSignal: null,
-    currentBalance: initialBalance,
+    currentBalance: initialBalance * instruments.length,
     candlesProcessed: 0,
-    totalCandles: candles.length,
+    totalCandles,
     currentTimestamp: new Date(0),
     progress: 0,
     trades: [],
@@ -86,17 +97,15 @@ function buildInitialState(candles: OhlcCandle[], initialBalance: number): Backt
 // ── useBacktest hook ──────────────────────────────────────────────────────────
 
 export function useBacktest(
-  candles: OhlcCandle[],
-  strategy: StrategyRunner,
+  instruments: InstrumentData[],
   initialBalance: number,
 ) {
   const [state, setState] = useState<BacktestState>(() =>
-    buildInitialState(candles, initialBalance),
+    buildInitialState(instruments, initialBalance),
   );
   const [speed, setSpeedState] = useState<SpeedLevel>(10);
 
-  const timeMachineRef = useRef<TimeMachine | null>(null);
-  const portfolioRef = useRef<Portfolio | null>(null);
+  const runtimesRef = useRef<InstrumentRuntime[]>([]);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const statusRef = useRef<BacktestStatus>('IDLE');
   const speedRef = useRef<SpeedLevel>(10);
@@ -112,93 +121,115 @@ export function useBacktest(
     }
   }, []);
 
-  // ── Tick: process N candles and update state ─────────────────────────────────
+  // ── Tick: process N candles per instrument and update state ──────────────────
 
   const tick = useCallback(() => {
-    const tm = timeMachineRef.current;
-    const portfolio = portfolioRef.current;
-    if (!tm || !portfolio || statusRef.current !== 'RUNNING') return;
+    const runtimes = runtimesRef.current;
+    if (runtimes.length === 0 || statusRef.current !== 'RUNNING') return;
 
     const { batchSize } = SPEED_CONFIG[speedRef.current];
-    const prevTradeCount = portfolio.getTrades().length;
 
     let lastWindow: [OhlcCandle, OhlcCandle, OhlcCandle] | null = null;
     let lastSignal: TradeSignal | null = null;
-    let done = false;
+    const batchNewTrades: ExecutedTrade[] = [];
 
-    for (let i = 0; i < batchSize; i++) {
-      const window = tm.next();
-      if (!window) {
-        done = true;
-        break;
-      }
+    for (const runtime of runtimes) {
+      if (runtime.done) continue;
 
-      const [, , c3] = window;
+      const { timeMachine, portfolio, strategy } = runtime;
+      const prevTradeCount = portfolio.getTrades().length;
 
-      // Check open position exit
-      if (portfolio.hasOpenPosition()) {
-        const slHit = portfolio.checkStopLoss(c3);
-        if (!slHit) portfolio.checkTakeProfit(c3);
-      }
+      let localLastWindow: [OhlcCandle, OhlcCandle, OhlcCandle] | null = null;
+      let localLastSignal: TradeSignal | null = null;
 
-      // Analyze for new entry
-      let signal: TradeSignal | null = null;
-      if (!portfolio.hasOpenPosition()) {
-        try {
-          signal = strategy.analyze(window);
-        } catch {
-          // Skip candle on strategy error — consistent with BacktestRunner behaviour
-          strategyErrorCountRef.current++;
+      for (let i = 0; i < batchSize; i++) {
+        const window = timeMachine.next();
+        if (!window) {
+          runtime.done = true;
+          break;
         }
-        if (signal) portfolio.openPosition(signal, c3.open_time);
+
+        const [, , c3] = window;
+
+        // Check open position exit
+        if (portfolio.hasOpenPosition()) {
+          const slHit = portfolio.checkStopLoss(c3);
+          if (!slHit) portfolio.checkTakeProfit(c3);
+        }
+
+        // Analyze for new entry
+        let signal: TradeSignal | null = null;
+        if (!portfolio.hasOpenPosition()) {
+          try {
+            signal = strategy.analyze(window);
+          } catch {
+            strategyErrorCountRef.current++;
+          }
+          if (signal) portfolio.openPosition(signal, c3.open_time);
+        }
+
+        localLastWindow = window;
+        localLastSignal = signal;
       }
 
-      lastWindow = window;
-      lastSignal = signal;
+      // Notify strategy of trades closed during this batch
+      const allTrades = portfolio.getTrades();
+      const newTrades = allTrades.slice(prevTradeCount);
+      for (const trade of newTrades) {
+        strategy.onTradeExecuted(trade);
+        batchNewTrades.push(trade);
+      }
+
+      if (localLastWindow) {
+        lastWindow = localLastWindow;
+        lastSignal = localLastSignal;
+      }
     }
 
-    // Notify strategy of trades closed during this batch
-    const allTrades = portfolio.getTrades();
-    const newTrades = allTrades.slice(prevTradeCount);
-    for (const trade of newTrades) {
-      strategy.onTradeExecuted(trade);
-    }
-
-    // Maintain a capped ring buffer of the 10 most recent trades
-    if (newTrades.length > 0) {
-      const combined = recentTradesRef.current.concat(newTrades);
+    // Maintain a capped ring buffer of the 10 most recent trades across all instruments
+    if (batchNewTrades.length > 0) {
+      const combined = recentTradesRef.current.concat(batchNewTrades);
       recentTradesRef.current = combined.length > 10 ? combined.slice(-10) : combined;
     }
 
-    if (done) {
+    const allDone = runtimes.every((r) => r.done);
+    if (allDone) {
       statusRef.current = 'COMPLETE';
       stopInterval();
     }
 
-    const progressStr = tm.progress();
-    const parts = progressStr.split(' / ');
-    const rawProcessed = parseInt((parts[0] ?? '0').replace(/,/g, ''), 10);
-    const rawTotal = parseInt((parts[1] ?? '1').replace(/,/g, ''), 10);
-    const processed = Number.isNaN(rawProcessed) ? 0 : rawProcessed;
-    const total = Number.isNaN(rawTotal) ? 1 : rawTotal;
+    // Aggregate state across all instruments
+    const allTrades = runtimes.flatMap((r) => r.portfolio.getTrades());
+    const totalBalance = runtimes.reduce((sum, r) => sum + r.portfolio.getBalance(), 0);
+
+    // Sum progress across all instruments
+    let totalProcessed = 0;
+    let totalCandlesSum = 0;
+    for (const runtime of runtimes) {
+      const progressStr = runtime.timeMachine.progress();
+      const parts = progressStr.split(' / ');
+      const rawProcessed = parseInt((parts[0] ?? '0').replace(/,/g, ''), 10);
+      totalProcessed += Number.isNaN(rawProcessed) ? 0 : rawProcessed;
+      totalCandlesSum += runtime.timeMachine.total;
+    }
 
     setState({
-      status: done ? 'COMPLETE' : statusRef.current,
+      status: allDone ? 'COMPLETE' : statusRef.current,
       currentCandles: lastWindow,
       patternData: lastWindow ? extractPatternData(lastWindow, lastSignal) : null,
       tradeSignal: lastSignal,
-      currentBalance: portfolio.getBalance(),
-      candlesProcessed: processed,
-      totalCandles: total,
+      currentBalance: totalBalance,
+      candlesProcessed: totalProcessed,
+      totalCandles: totalCandlesSum,
       currentTimestamp: lastWindow ? new Date(lastWindow[2].open_time * 1000) : new Date(0),
-      progress: total > 0 ? (processed / total) * 100 : 0,
+      progress: totalCandlesSum > 0 ? (totalProcessed / totalCandlesSum) * 100 : 0,
       trades: recentTradesRef.current,
-      metrics: calculateMetrics(allTrades, initialBalance),
+      metrics: calculateMetrics(allTrades, initialBalance * runtimes.length),
       strategyErrorCount: strategyErrorCountRef.current,
-      effectiveTpMultiplier: strategy.getEffectiveTpMultiplier?.(),
-      effectiveRiskPct: strategy.getEffectiveRiskPct?.(),
+      effectiveTpMultiplier: runtimes[0]?.strategy.getEffectiveTpMultiplier?.(),
+      effectiveRiskPct: runtimes[0]?.strategy.getEffectiveRiskPct?.(),
     });
-  }, [strategy, initialBalance, stopInterval]);
+  }, [initialBalance, stopInterval]);
 
   // ── Start interval at given speed ────────────────────────────────────────────
 
@@ -214,10 +245,15 @@ export function useBacktest(
   // ── Init / reset engine state ────────────────────────────────────────────────
 
   const initEngine = useCallback(() => {
-    timeMachineRef.current = new TimeMachine(candles);
-    portfolioRef.current = new Portfolio(initialBalance);
+    runtimesRef.current = instruments.map(({ instrument, candles, strategy }) => ({
+      instrument,
+      strategy,
+      timeMachine: new TimeMachine(candles),
+      portfolio: new Portfolio(initialBalance, instrument),
+      done: false,
+    }));
     statusRef.current = 'IDLE';
-  }, [candles, initialBalance]);
+  }, [instruments, initialBalance]);
 
   // ── Public controls ──────────────────────────────────────────────────────────
 
@@ -244,30 +280,39 @@ export function useBacktest(
 
   const restart = useCallback(() => {
     stopInterval();
-    strategy.reset();
+    for (const runtime of runtimesRef.current) {
+      runtime.strategy.reset();
+    }
     initEngine();
     recentTradesRef.current = [];
     strategyErrorCountRef.current = 0;
-    setState(buildInitialState(candles, initialBalance));
-  }, [stopInterval, strategy, initEngine, candles, initialBalance]);
+    setState(buildInitialState(instruments, initialBalance));
+  }, [stopInterval, initEngine, instruments, initialBalance]);
 
   const saveResults = useCallback(() => {
-    const allTrades = portfolioRef.current?.getTrades() ?? [];
-    const balance = portfolioRef.current?.getBalance() ?? initialBalance;
-    const metrics = calculateMetrics(allTrades, initialBalance);
+    const runtimes = runtimesRef.current;
+    const allTrades = runtimes.flatMap((r) => r.portfolio.getTrades());
+    const totalBalance = runtimes.reduce((sum, r) => sum + r.portfolio.getBalance(), 0);
+    const totalInitialBalance = initialBalance * runtimes.length;
+    const metrics = calculateMetrics(allTrades, totalInitialBalance);
     const timestamp = new Date().toISOString();
     const safeTimestamp = timestamp.replace(/[:.]/g, '-').slice(0, 19);
     const exportDir = './export';
     mkdirSync(exportDir, { recursive: true });
-    const basename = `${exportDir}/backtest-${strategy.name}-${safeTimestamp}`;
+
+    const strategyName = runtimes[0]?.strategy.name ?? 'unknown';
+    const strategyVersion = runtimes[0]?.strategy.version ?? '0.0.0';
+    const basename = `${exportDir}/backtest-${strategyName}-${safeTimestamp}`;
 
     // JSON
     const payload = {
       metadata: {
-        strategy: strategy.name,
-        version: strategy.version,
+        strategy: strategyName,
+        version: strategyVersion,
+        instruments: runtimes.map((r) => r.instrument),
         initialBalance,
-        finalBalance: balance,
+        totalInitialBalance,
+        finalBalance: totalBalance,
         runDate: timestamp,
       },
       trades: allTrades,
@@ -291,10 +336,10 @@ export function useBacktest(
     // CSV via shared InMemoryTradeLog
     const tradeLog = new InMemoryTradeLog();
     for (const trade of allTrades) {
-      tradeLog.logTrade(trade, strategy.name, strategy.version);
+      tradeLog.logTrade(trade, strategyName, strategyVersion);
     }
     tradeLog.exportToCSV(`${basename}.csv`);
-  }, [strategy, initialBalance]);
+  }, [initialBalance]);
 
   const setSpeed = useCallback(
     (newSpeed: SpeedLevel) => {

--- a/apps/trading-simulator/src/tui/types.ts
+++ b/apps/trading-simulator/src/tui/types.ts
@@ -2,6 +2,14 @@ import type { CandleLabel } from '@crypto-terminal/trade-formula';
 import type { OhlcCandle, ExecutedTrade, TradeSignal, StrategyRunner } from '../engine/types.js';
 import type { PerformanceMetrics } from '../shared/metrics.js';
 
+// ── Per-instrument data bundle passed to the TUI ──────────────────────────────
+
+export interface InstrumentData {
+  instrument: string;
+  candles: OhlcCandle[];
+  strategy: StrategyRunner;
+}
+
 // ── Backtest status ────────────────────────────────────────────────────────────
 
 export type BacktestStatus = 'IDLE' | 'RUNNING' | 'PAUSED' | 'COMPLETE';
@@ -54,10 +62,8 @@ export interface BacktestState {
 // ── Props for the TUI App root component ─────────────────────────────────────
 
 export interface TuiAppProps {
-  candles: OhlcCandle[];
-  strategy: StrategyRunner;
+  instruments: InstrumentData[];
   strategyName: string;
-  instrument: string;
   timeframe: string;
   initialBalance: number;
   riskPercent: number;

--- a/apps/trading-simulator/tests/shared-execution-log.test.ts
+++ b/apps/trading-simulator/tests/shared-execution-log.test.ts
@@ -9,6 +9,7 @@ import type { ExecutedTrade } from '../src/engine/types.js';
 function makeTrade(overrides: Partial<ExecutedTrade> = {}): ExecutedTrade {
   return {
     id: 1,
+    instrument: 'BTCUSDT',
     entryTimestamp: new Date('2026-01-01T00:00:00Z'),
     exitTimestamp: new Date('2026-01-01T01:00:00Z'),
     direction: 'LONG',


### PR DESCRIPTION
Implements #issue62 - multi-instrument support for the trading simulator.

## Changes

- Interactive instrument selection prompt for both CLI and TUI modes
- Remove INSTRUMENT env variable dependency
- Fetch available instruments from Postgres DB
- TUI: parallel multi-instrument execution in useBacktest hook
- CLI: sequential per-instrument backtest runs
- Add Ticker column to Trade Log (TUI + CSV)
- instrument field in JSON export metadata and trade records
- `--instruments=` CLI flag to bypass interactive prompt

Closes #62

Generated with [Claude Code](https://claude.ai/code)